### PR TITLE
Static binaries

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -107,7 +107,7 @@ release-assets:
         GOOS=$(echo "$platform" | cut -d'/' -f1)
         GOARCH=$(echo "$platform" | cut -d'/' -f2)
         BIN=$CI_PROJECT_NAME-$GOOS-$GOARCH
-        go build -o $BIN -ldflags "-X \"enix.io/$CI_PROJECT_NAME/internal.Version=${CI_COMMIT_REF_SLUG:1}\"" ./cmd/$CI_PROJECT_NAME
+        go build -tags netgo,osusergo -o $BIN -ldflags "-X \"enix.io/$CI_PROJECT_NAME/internal.Version=${CI_COMMIT_REF_SLUG:1}\"" ./cmd/$CI_PROJECT_NAME
         ./test/upload-release.sh "github_api_token=$GITHUB_TOKEN" "owner=enix" "repo=$CI_PROJECT_NAME" "tag=$CI_COMMIT_TAG" "filename=$BIN"
       done
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ ENV GOARCH=${TARGETARCH}
 
 ARG VERSION="0.0.0"
 
-RUN go build -ldflags "-X \"enix.io/x509-certificate-exporter/internal.Version=${VERSION}\"" ./cmd/x509-certificate-exporter
+RUN go build -tags netgo,osusergo -ldflags "-X \"enix.io/x509-certificate-exporter/internal.Version=${VERSION}\"" ./cmd/x509-certificate-exporter
 
 
 ## Production Stage


### PR DESCRIPTION
Use the `osusergo` and `netgo` build tags to skip building the cgo parts. The result is a static binary that doesn't depend on the local libc.

```
# ldd x509-certificate-exporter
/lib/ld-musl-x86_64.so.1: x509-certificate-exporter: Not a valid dynamic program
```