### PR TITLE
Made all alerting severity configurable

### DIFF
--- a/deploy/chart/Chart.yaml
+++ b/deploy/chart/Chart.yaml
@@ -1,7 +1,7 @@
 # when bumping version, please:
 # - replace the "changes" annotation with new content
 # - update "containsSecurityUpdates" if needed
-version: 1.20.0
+version: 1.20.1
 appVersion: 2.12.0
 annotations:
   artifacthub.io/containsSecurityUpdates: 'false'

--- a/deploy/chart/README.md
+++ b/deploy/chart/README.md
@@ -391,6 +391,8 @@ in the container namespace.
 | prometheusRules.readErrorsSeverity | string | `"warning"` | Severity for the X509ExporterReadErrors alerting rule |
 | prometheusRules.alertOnCertificateErrors | bool | `true` | Should the CertificateError alerting rule be created to notify when the exporter can't decode or process a certificate. Depends on `exposePerCertificateErrorMetrics` to be enabled too. |
 | prometheusRules.certificateErrorsSeverity | string | `"warning"` | Severity for the CertificateError alerting rule |
+| prometheusRules.certificateRenewalsSeverity | string | `"warning"` | Severity for the CertificateRenewal alerting rule |
+| prometheusRules.certificateExpirationsSeverity | string | `"critical"` | Severity for the CertificateExpiration alerting rule |
 | prometheusRules.warningDaysLeft | int | `28` | Raise a warning alert when this little days are left before a certificate expiration (cert-manager would renew Let's Encrypt certs before day 29) |
 | prometheusRules.criticalDaysLeft | int | `14` | Raise a critical alert when this little days are left before a certificate expiration (two weeks to deal with ACME rate limiting should this be an issue) |
 | prometheusRules.extraLabels | object | `{}` | Extra labels to add on PrometheusRule ressources |

--- a/deploy/chart/templates/prometheusrule.yaml
+++ b/deploy/chart/templates/prometheusrule.yaml
@@ -36,7 +36,7 @@ spec:
       expr: ((x509_cert_not_after - time()) / 86400) < {{ .Values.prometheusRules.warningDaysLeft }}
       for: 15m
       labels:
-        severity: warning
+        severity: {{ .Values.prometheusRules.certificateRenewalsSeverity }}
       annotations:
         summary: Certificate should be renewed
         description: Certificate for "{{ "{{" }} $labels.subject_CN {{ "}}" }}" should be renewed {{ "{{if" }} $labels.secret_name {{ "}}" }}in Kubernetes secret "{{ "{{" }} $labels.secret_namespace {{ "}}" }}/{{ "{{" }} $labels.secret_name {{ "}}" }}"{{ "{{else}}" }}at location "{{ "{{" }} $labels.filepath {{ "}}" }}"{{ "{{end}}" }}
@@ -44,7 +44,7 @@ spec:
       expr: ((x509_cert_not_after - time()) / 86400) < {{ .Values.prometheusRules.criticalDaysLeft }}
       for: 15m
       labels:
-        severity: critical
+        severity: {{ .Values.prometheusRules.certificateExpirationsSeverity }}
       annotations:
         summary: Certificate is about to expire
         description: Certificate for "{{ "{{" }} $labels.subject_CN {{ "}}" }}" is about to expire {{ "{{if" }} $labels.secret_name {{ "}}" }}in Kubernetes secret "{{ "{{" }} $labels.secret_namespace {{ "}}" }}/{{ "{{" }} $labels.secret_name {{ "}}" }}"{{ "{{else}}" }}at location "{{ "{{" }} $labels.filepath {{ "}}" }}"{{ "{{end}}" }}

--- a/deploy/chart/values.yaml
+++ b/deploy/chart/values.yaml
@@ -264,6 +264,10 @@ prometheusRules:
   alertOnCertificateErrors: true
   # -- Severity for the CertificateError alerting rule
   certificateErrorsSeverity: warning
+  # -- Severity for the CertificateRenewal alerting rule
+  certificateRenewalsSeverity: warning
+  # -- Severity for the CertificateExpiration alerting rule
+  certificateExpirationsSeverity: critical
   # -- Raise a warning alert when this little days are left before a certificate expiration (cert-manager would renew Let's Encrypt certs before day 29)
   warningDaysLeft: 28
   # -- Raise a critical alert when this little days are left before a certificate expiration (two weeks to deal with ACME rate limiting should this be an issue)


### PR DESCRIPTION
The environment where we would like to use `x509-certificate-exporter` we have fine-tuned severities.

Your solution is a perfect match what we need. Only configurable severity is what missing.

I hope you will take a look at my PR.