### PR TITLE
Feature/customizable alerts

### DIFF
--- a/deploy/chart/README.md
+++ b/deploy/chart/README.md
@@ -398,6 +398,9 @@ in the container namespace.
 | prometheusRules.extraLabels | object | `{}` | Extra labels to add on PrometheusRule ressources |
 | prometheusRules.alertExtraLabels | object | `{}` | Extra labels to add on PrometheusRule rules |
 | prometheusRules.rulePrefix | string | `""` | Extra rulePrefix to PrometheusRule rules |
+| prometheusRules.disableBuiltinAlertGroup | bool | `false` | Skip all built-in alerts when using extraAlertGroups |
+| prometheusRules.extraAlertGroups | list | `[]` | Additional alert groups for custom configuration (example in `values.yaml`) |
+| extraDeploy | list | `[]` | Extra objects to deploy with the release |
 
 ## ⚖️ License
 

--- a/deploy/chart/templates/extra.yaml
+++ b/deploy/chart/templates/extra.yaml
@@ -1,0 +1,8 @@
+{{- range .Values.extraDeploy }}
+---
+    {{- if typeIs "string" . }}
+        {{- tpl . $ }}
+    {{- else }}
+        {{- tpl (. | toYaml) $ }}
+    {{- end }}
+{{- end }}

--- a/deploy/chart/templates/prometheusrule.yaml
+++ b/deploy/chart/templates/prometheusrule.yaml
@@ -11,6 +11,11 @@ metadata:
     {{- end }}
 spec:
   groups:
+  {{- if .Values.prometheusRules.disableBuiltinAlertGroup }}
+    {{- if not (len .Values.prometheusRules.extraAlertGroups) }}
+      {{ fail "Extra alert groups (extraAlertGroups) are required when disableBuiltinAlertGroup is set!" }}
+    {{- end }}
+  {{- else }}
   - name: x509-certificate-exporter.rules
     rules:
     {{- if .Values.prometheusRules.alertOnReadErrors }}
@@ -61,4 +66,8 @@ spec:
       annotations:
         summary: Certificate is about to expire
         description: Certificate for "{{ "{{" }} $labels.subject_CN {{ "}}" }}" is about to expire {{ "{{if" }} $labels.secret_name {{ "}}" }}in Kubernetes secret "{{ "{{" }} $labels.secret_namespace {{ "}}" }}/{{ "{{" }} $labels.secret_name {{ "}}" }}"{{ "{{else}}" }}at location "{{ "{{" }} $labels.filepath {{ "}}" }}"{{ "{{end}}" }}
+  {{- end }}
+{{- range .Values.prometheusRules.extraAlertGroups }}
+  - {{ tpl (toYaml .) $ | indent 4 | trim }}
+{{- end }}
 {{- end }}

--- a/deploy/chart/values.yaml
+++ b/deploy/chart/values.yaml
@@ -287,6 +287,20 @@ prometheusRules:
   alertExtraLabels: {}
   # -- Extra rulePrefix to PrometheusRule rules
   rulePrefix: ""
+  # -- Skip all built-in alerts when using extraAlertGroups
+  disableBuiltinAlertGroup: false
+  # -- Additional alert groups for custom configuration (example in `values.yaml`)
+  extraAlertGroups: []
+  # - name: custom.rules
+  #   rules:
+  #   - alert: X509ExporterReadErrorsCustom
+  #     expr: x509_read_errors > 0
+  #     for: 30m
+  #     labels:
+  #       severity: warning
+  #     annotations:
+  #       summary: Error events exist for this x509-certificate-exporter
+  #       description: This x509-certificate-exporter instance has experienced parse errors in the past.
 
 # -- Extra objects to deploy with the release
 extraDeploy: []

--- a/deploy/chart/values.yaml
+++ b/deploy/chart/values.yaml
@@ -1,10 +1,10 @@
 ---
 # Note to contributors:
 # We use helm-docs to generate README.md from comments in this file, so the
-# tool should be run again when values.yaml is modified. We appreciated PRs
+# tool should be run again when values.yaml is modified. We appreciate PRs
 # that include this change, but you don't have to.
 # However we wish to preserve ordering and not sort the whole list by
-# alphanumeric order, because it doesn't suit well newcomers.
+# alphanumeric order, because it doesn't suit well new users.
 # So please use this command if you run it:
 #  $ helm-docs --sort-values-order file
 

--- a/deploy/chart/values.yaml
+++ b/deploy/chart/values.yaml
@@ -287,3 +287,6 @@ prometheusRules:
   alertExtraLabels: {}
   # -- Extra rulePrefix to PrometheusRule rules
   rulePrefix: ""
+
+# -- Extra objects to deploy with the release
+extraDeploy: []


### PR DESCRIPTION
In response to #38 regarding PrometheusRule customization:
- allow injection of additional alert groups
- make the built-in alert group optional by a disabling flag
- permit deployment of extra objects with the release