### PR TITLE
New metric with exporter version and build information

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -206,7 +206,7 @@ jobs:
 
           ldflags=()
           ldflags+=("-X github.com/enix/x509-certificate-exporter/v3/internal.Version=${{ needs.semver.outputs.version }}")
-          ldflags+=("-X github.com/enix/x509-certificate-exporter/v3/internal.CommitHash=${{ github.sha }}")
+          ldflags+=("-X github.com/enix/x509-certificate-exporter/v3/internal.Revision=${{ github.sha }}")
           ldflags+=("-X github.com/enix/x509-certificate-exporter/v3/internal.BuildDateTime=$(date --utc --iso-8601=seconds)")
 
           cd ${{ github.workspace }}/repository

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ ENV GOARCH=${TARGETARCH}
 RUN go build -v \
   -tags netgo,osusergo \
   -ldflags "-X \"github.com/enix/x509-certificate-exporter/v3/internal.Version=${VERSION}\" \
-            -X \"github.com/enix/x509-certificate-exporter/v3/internal.CommitHash=${VCS_REF}\" \
+            -X \"github.com/enix/x509-certificate-exporter/v3/internal.Revision=${VCS_REF}\" \
             -X \"github.com/enix/x509-certificate-exporter/v3/internal.BuildDateTime=$(date -u -Iseconds)\"" \
   ./cmd/x509-certificate-exporter
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ The following metrics are available:
 - `x509_cert_valid_since_seconds` (optional)
 - `x509_cert_error` (optional)
 - `x509_read_errors`
+- `x509_exporter_build_info`
 
 ### Prometheus Alerts
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@ The following metrics are available:
 - `x509_cert_not_before`
 - `x509_cert_not_after`
 - `x509_cert_expired`
+- `x509_cert_expires_in_seconds` (optional)
+- `x509_cert_valid_since_seconds` (optional)
+- `x509_cert_error` (optional)
 - `x509_read_errors`
 
 ### Prometheus Alerts

--- a/cmd/x509-certificate-exporter/main.go
+++ b/cmd/x509-certificate-exporter/main.go
@@ -109,7 +109,7 @@ func main() {
 		}
 	}
 
-	log.Infof("starting %s version %s (%s) (%s)", path.Base(os.Args[0]), internal.Version, internal.CommitHash, internal.BuildDateTime)
+	log.Infof("starting %s version %s (%s) (%s)", path.Base(os.Args[0]), internal.Version, internal.Revision, internal.BuildDateTime)
 	rand.Seed(time.Now().UnixNano())
 	exporter.ListenAndServe()
 }

--- a/deploy/charts/x509-certificate-exporter/README.md
+++ b/deploy/charts/x509-certificate-exporter/README.md
@@ -18,6 +18,7 @@ The following metrics are available:
 * `x509_cert_valid_since_seconds` (optional)
 * `x509_cert_error` (optional)
 * `x509_read_errors`
+* `x509_exporter_build_info`
 
 Best when used with the [Grafana Dashboard](https://grafana.com/grafana/dashboards/13922) ID `13922`:
 

--- a/deploy/charts/x509-certificate-exporter/README.md
+++ b/deploy/charts/x509-certificate-exporter/README.md
@@ -14,6 +14,8 @@ The following metrics are available:
 * `x509_cert_not_before`
 * `x509_cert_not_after`
 * `x509_cert_expired`
+* `x509_cert_expires_in_seconds` (optional)
+* `x509_cert_valid_since_seconds` (optional)
 * `x509_cert_error` (optional)
 * `x509_read_errors`
 

--- a/deploy/charts/x509-certificate-exporter/README.md.gotmpl
+++ b/deploy/charts/x509-certificate-exporter/README.md.gotmpl
@@ -18,6 +18,7 @@ The following metrics are available:
 * `x509_cert_valid_since_seconds` (optional)
 * `x509_cert_error` (optional)
 * `x509_read_errors`
+* `x509_exporter_build_info`
 
 Best when used with the [Grafana Dashboard](https://grafana.com/grafana/dashboards/13922) ID `13922`:
 

--- a/deploy/charts/x509-certificate-exporter/README.md.gotmpl
+++ b/deploy/charts/x509-certificate-exporter/README.md.gotmpl
@@ -14,6 +14,8 @@ The following metrics are available:
 * `x509_cert_not_before`
 * `x509_cert_not_after`
 * `x509_cert_expired`
+* `x509_cert_expires_in_seconds` (optional)
+* `x509_cert_valid_since_seconds` (optional)
 * `x509_cert_error` (optional)
 * `x509_read_errors`
 

--- a/internal/version.go
+++ b/internal/version.go
@@ -2,5 +2,5 @@ package internal
 
 // Version and build informations set at link time
 var Version = "0.0.0"
-var CommitHash = ""
+var Revision = ""
 var BuildDateTime = ""


### PR DESCRIPTION
A new metric `x509_exporter_build_info` with labels of constant values:
- `version`: running version of the exporter
- `revision`: commit id used for this build
- `built`: date and time of build
- `goversion`: Go version used
- `goos`: target Operating System
- `goarch`: target machine architecture