### PR TITLE
chore: add probes on all containers

### DIFF
--- a/deploy/charts/x509-certificate-exporter/templates/daemonset.yaml
+++ b/deploy/charts/x509-certificate-exporter/templates/daemonset.yaml
@@ -146,7 +146,7 @@ spec:
       {{- if not $.Values.rbacProxy.enabled }}
         livenessProbe:
           httpGet:
-            path: /metrics
+            path: /healthz
             port: metrics
           initialDelaySeconds: 5
           periodSeconds: 3
@@ -155,7 +155,7 @@ spec:
           containerPort: {{ $.Values.podListenPort }}
         readinessProbe:
           httpGet:
-            path: /metrics
+            path: /healthz
             port: metrics
           initialDelaySeconds: 5
           periodSeconds: 3
@@ -179,7 +179,7 @@ spec:
               fieldPath: status.podIP
         livenessProbe:
           httpGet:
-            path: /metrics
+            path: /healthz
             port: metrics
           initialDelaySeconds: 5
           periodSeconds: 3
@@ -188,7 +188,7 @@ spec:
           containerPort: {{ $.Values.podListenPort }}
         readinessProbe:
           httpGet:
-            path: /metrics
+            path: /healthz
             port: metrics
           initialDelaySeconds: 5
           periodSeconds: 3

--- a/deploy/charts/x509-certificate-exporter/templates/daemonset.yaml
+++ b/deploy/charts/x509-certificate-exporter/templates/daemonset.yaml
@@ -144,9 +144,21 @@ spec:
         - {{ tpl (. | toYaml) $ | indent 10 | trim }}
         {{- end }}
       {{- if not $.Values.rbacProxy.enabled }}
+        livenessProbe:
+          httpGet:
+            path: /metrics
+            port: metrics
+          initialDelaySeconds: 5
+          periodSeconds: 3
         ports:
         - name: metrics
           containerPort: {{ $.Values.podListenPort }}
+        readinessProbe:
+          httpGet:
+            path: /metrics
+            port: metrics
+          initialDelaySeconds: 5
+          periodSeconds: 3
       {{- else }}
       - name: kube-rbac-proxy
         {{- with $.Values.rbacProxy.securityContext }}
@@ -165,9 +177,21 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
+        livenessProbe:
+          httpGet:
+            path: /metrics
+            port: metrics
+          initialDelaySeconds: 5
+          periodSeconds: 3
         ports:
         - name: metrics
           containerPort: {{ $.Values.podListenPort }}
+        readinessProbe:
+          httpGet:
+            path: /metrics
+            port: metrics
+          initialDelaySeconds: 5
+          periodSeconds: 3
         {{- with $.Values.rbacProxy.resources }}
         resources:
         {{- . | toYaml | trim | nindent 10 }}

--- a/deploy/charts/x509-certificate-exporter/templates/deployment.yaml
+++ b/deploy/charts/x509-certificate-exporter/templates/deployment.yaml
@@ -150,7 +150,7 @@ spec:
         - --listen-address=:{{ .Values.podListenPort }}
         livenessProbe:
           httpGet:
-            path: /metrics
+            path: /healthz
             port: metrics
           initialDelaySeconds: 5
           periodSeconds: 3
@@ -159,7 +159,7 @@ spec:
           containerPort: {{ .Values.podListenPort }}
         readinessProbe:
           httpGet:
-            path: /metrics
+            path: /healthz
             port: metrics
           initialDelaySeconds: 5
           periodSeconds: 3
@@ -184,7 +184,7 @@ spec:
               fieldPath: status.podIP
         livenessProbe:
           httpGet:
-            path: /metrics
+            path: /healthz
             port: metrics
           initialDelaySeconds: 5
           periodSeconds: 3
@@ -193,7 +193,7 @@ spec:
           containerPort: {{ .Values.podListenPort }}
         readinessProbe:
           httpGet:
-            path: /metrics
+            path: /healthz
             port: metrics
           initialDelaySeconds: 5
           periodSeconds: 3

--- a/deploy/charts/x509-certificate-exporter/templates/deployment.yaml
+++ b/deploy/charts/x509-certificate-exporter/templates/deployment.yaml
@@ -148,9 +148,21 @@ spec:
         {{- end }}
       {{- if not .Values.rbacProxy.enabled }}
         - --listen-address=:{{ .Values.podListenPort }}
+        livenessProbe:
+          httpGet:
+            path: /metrics
+            port: metrics
+          initialDelaySeconds: 5
+          periodSeconds: 3
         ports:
         - name: metrics
           containerPort: {{ .Values.podListenPort }}
+        readinessProbe:
+          httpGet:
+            path: /metrics
+            port: metrics
+          initialDelaySeconds: 5
+          periodSeconds: 3
       {{- else }}
         - --listen-address=:{{ .Values.rbacProxy.upstreamListenPort }}
       - name: kube-rbac-proxy
@@ -170,9 +182,21 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
+        livenessProbe:
+          httpGet:
+            path: /metrics
+            port: metrics
+          initialDelaySeconds: 5
+          periodSeconds: 3
         ports:
         - name: metrics
           containerPort: {{ .Values.podListenPort }}
+        readinessProbe:
+          httpGet:
+            path: /metrics
+            port: metrics
+          initialDelaySeconds: 5
+          periodSeconds: 3
         {{- with .Values.rbacProxy.resources }}
         resources:
         {{- . | toYaml | trim | nindent 10 }}

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.23.4
 require (
 	github.com/KimMachineGun/automemlimit v0.7.0
 	github.com/bmatcuk/doublestar/v4 v4.7.1
+	github.com/dimiro1/health v0.0.0-20231118160444-e388c68d7d7e
 	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/pborman/getopt/v2 v2.1.0
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,4 @@
+github.com/DATA-DOG/go-sqlmock v1.3.3/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
 github.com/KimMachineGun/automemlimit v0.7.0 h1:7G06p/dMSf7G8E6oq+f2uOPuVncFyIlDI/pBWK49u88=
 github.com/KimMachineGun/automemlimit v0.7.0/go.mod h1:QZxpHaGOQoYvFhv/r4u3U0JTC2ZcOwbSr11UZF46UBM=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
@@ -10,12 +11,15 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dimiro1/health v0.0.0-20231118160444-e388c68d7d7e h1:MPc833fnULks8D8FZwut9nDjRnxZlo4kmpAph09ChXw=
+github.com/dimiro1/health v0.0.0-20231118160444-e388c68d7d7e/go.mod h1:k1oeNKpjma0O03u8mKfiKIDXPvqA3VDYq9+QNcPPvuE=
 github.com/emicklei/go-restful/v3 v3.12.1 h1:PJMDIM/ak7btuL8Ex0iYET9hxM3CI2sjZtzpL63nKAU=
 github.com/emicklei/go-restful/v3 v3.12.1/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
 github.com/enix/doublestar/v4 v4.0.0-20230517083426-fa6d1b0d071d h1:XgDfI7CiZqA4yTAb1gGilrci8zfoHqN311QqHOor3Pw=
 github.com/enix/doublestar/v4 v4.0.0-20230517083426-fa6d1b0d071d/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 github.com/fxamacker/cbor/v2 v2.7.0 h1:iM5WgngdRBanHcxugY4JySA0nk1wZorNOpTgCMedv5E=
 github.com/fxamacker/cbor/v2 v2.7.0/go.mod h1:pxXPTn3joSm21Gbwsv0w9OSA2y1HFR9qXEeXQVeNoDQ=
+github.com/garyburd/redigo v0.0.0-20160302234602-4ed1111375cb/go.mod h1:NR3MbYisc3/PwhQ00EMzDiPmrwpPxAn5GI05/YaO1SY=
 github.com/go-logr/logr v1.4.2 h1:6pFjapn8bFcIbiKo3XT4j/BhANplGihG6tvd+8rYgrY=
 github.com/go-logr/logr v1.4.2/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
 github.com/go-openapi/jsonpointer v0.21.0 h1:YgdVicSA9vH5RiHs9TZW5oyafXZFc6+2Vc1rr/O9oNQ=
@@ -31,6 +35,7 @@ github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
 github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek=
 github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
+github.com/gomodule/redigo v2.0.0+incompatible/go.mod h1:B4C85qUVwatsJoIUNIfCRsp7qO0iAmpGFZ4EELWSbC4=
 github.com/google/gnostic-models v0.6.9 h1:MU/8wDLif2qCXZmzncUQ/BOfxWfthHi63KqpoNbWqVw=
 github.com/google/gnostic-models v0.6.9/go.mod h1:CiWsm0s6BSQd1hRn8/QmxqB6BesYcbSZxsz9b0KuDBw=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
@@ -101,6 +106,7 @@ github.com/prometheus/exporter-toolkit v0.13.2 h1:Z02fYtbqTMy2i/f+xZ+UK5jy/bl1Ex
 github.com/prometheus/exporter-toolkit v0.13.2/go.mod h1:tCqnfx21q6qN1KA4U3Bfb8uWzXfijIrJz3/kTIqMV7g=
 github.com/prometheus/procfs v0.15.1 h1:YagwOFzUgYfKKHX6Dr+sHT7km/hxC76UB0learggepc=
 github.com/prometheus/procfs v0.15.1/go.mod h1:fB45yRUv8NstnjriLhBQLuOUt+WW4BsoGhij/e3PBqk=
+github.com/rafaeljusto/redigomock v0.0.0-20190202135759-257e089e14a1/go.mod h1:JaY6n2sDr+z2WTsXkOmNRUfDy6FN0L6Nk7x06ndm4tY=
 github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU5NdKM8=
 github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99yedzYV+kq4uf4=
 github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=

--- a/internal/exporter.go
+++ b/internal/exporter.go
@@ -21,6 +21,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 
 	"github.com/bmatcuk/doublestar/v4"
+	"github.com/dimiro1/health"
 	"github.com/prometheus/exporter-toolkit/web"
 	"k8s.io/client-go/kubernetes"
 )
@@ -118,6 +119,7 @@ func (exporter *Exporter) Listen() error {
 // Serve : Actually reply to requests
 func (exporter *Exporter) Serve() error {
 	mux := http.NewServeMux()
+	mux.Handle("/healthz", health.NewHandler())
 	mux.Handle("/metrics", promhttp.Handler())
 
 	exporter.server = &http.Server{


### PR DESCRIPTION
Hello,

I'm deploying this exporter on my cluster and we have a Kyverno policy that requires all pods to have liveness/readiness probes

Since those are exporters containers, I felt it was not a bad thing to make sure that the exporter is indeed listening on the exposed port

It's best practice to not have liveness === readiness but in this case I think this is acceptable, unless you want to take the time to create proper HTTP endpoints in the code to add a /live and a /ready (I can do it but I'm not sure this is worth it)