### PR TITLE
chore: add runAsNonRoot for the pods that don't require it

### DIFF
--- a/deploy/charts/x509-certificate-exporter/values.yaml
+++ b/deploy/charts/x509-certificate-exporter/values.yaml
@@ -91,7 +91,8 @@ secretsExporter:
   # -- Annotations added to Pods of the TLS Secrets exporter
   podAnnotations: {}
   # -- PodSecurityContext for Pods of the TLS Secrets exporter
-  podSecurityContext: {}
+  podSecurityContext:
+    runAsNonRoot: true
   # -- SecurityContext for containers of the TLS Secrets exporter
   # @default -- check `values.yaml`
   securityContext:
@@ -359,6 +360,7 @@ rbacProxy:
   securityContext:
     runAsUser: 65534
     runAsGroup: 65534
+    runAsNonRoot: true
     readOnlyRootFilesystem: true
     capabilities:
       drop:


### PR DESCRIPTION
The only pods that require to run as root (and already are) are the pods in hostPathsExporter

I've added the podSecurityContext "runAsNonRoot" to those that don't need it