### PR TITLE
Regex support for --secret-type

### DIFF
--- a/cmd/x509-certificate-exporter/main.go
+++ b/cmd/x509-certificate-exporter/main.go
@@ -57,8 +57,8 @@ func main() {
 
 	kubeConfig := getopt.StringLong("kubeconfig", 0, "", "Path to the kubeconfig file to use for requests. Takes precedence over the KUBECONFIG environment variable, and default path (~/.kube/config).", "path")
 
-	kubeSecretTypes := stringArrayFlag{}
-	getopt.FlagLong(&kubeSecretTypes, "secret-type", 's', "one or more kubernetes secret type & key to watch (e.g. \"kubernetes.io/tls:tls.crt\"")
+	kubeSecretTypePatterns := stringArrayFlag{}
+	getopt.FlagLong(&kubeSecretTypePatterns, "secret-type", 's', "one or more kubernetes secret type & key to watch (e.g. \"kubernetes.io/tls:tls.crt\"")
 
 	kubeConfigMapKeys := stringArrayFlag{}
 	getopt.FlagLong(&kubeConfigMapKeys, "configmap-keys", 'c', "keys in configmaps to watch")
@@ -116,6 +116,15 @@ func main() {
 	)
 	if err != nil {
 		slog.Error("Cannot set GOMEMLIMIT with automemlimit", "reason", err.Error())
+	}
+
+	kubeSecretTypes := make([]internal.KubeSecretType, 0)
+	for _, pattern := range kubeSecretTypePatterns {
+		kst, err := internal.ParseSecretType(pattern)
+		if err != nil {
+			log.Fatal("failed to parse --secret-type argument: ", err)
+		}
+		kubeSecretTypes = append(kubeSecretTypes, kst)
 	}
 
 	exporter := internal.Exporter{

--- a/internal/exporter_test.go
+++ b/internal/exporter_test.go
@@ -17,6 +17,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"strings"
 	"testing"
@@ -991,7 +992,7 @@ func checkLabels(t *testing.T, labels []*model.LabelPair, path string, isKube bo
 func testRequest(t *testing.T, exporter *Exporter, cb func(metrics []model.MetricFamily)) {
 	exporter.ListenAddress = listenAddress
 	if exporter.KubeSecretTypes == nil {
-		exporter.KubeSecretTypes = []string{"kubernetes.io/tls:tls.crt"}
+		exporter.KubeSecretTypes = []KubeSecretType{{Type: "kubernetes.io/tls", Regexp: regexp.MustCompile(`tls\.crt`)}}
 	}
 	exporter.DiscoverCertificates()
 

--- a/internal/kubernetes.go
+++ b/internal/kubernetes.go
@@ -32,15 +32,15 @@ func (exporter *Exporter) parseAllKubeObjects() ([]*certificateRef, []error) {
 	readCertificatesFromSecrets := func(secrets []v1.Secret) (outputs []*certificateRef) {
 		for _, secret := range secrets {
 			for _, secretType := range exporter.KubeSecretTypes {
-				typeAndKey := strings.Split(secretType, ":")
-
-				if secret.Type == v1.SecretType(typeAndKey[0]) && len(secret.Data[typeAndKey[1]]) > 0 {
-					outputs = append(outputs, &certificateRef{
-						path:          fmt.Sprintf("k8s/%s/%s", secret.GetNamespace(), secret.GetName()),
-						format:        certificateFormatKubeSecret,
-						kubeSecret:    secret,
-						kubeSecretKey: typeAndKey[1],
-					})
+				for key := range secret.Data {
+					if secretType.Matches(string(secret.Type), key) {
+						output = append(output, &certificateRef{
+							path:          fmt.Sprintf("k8s/%s/%s", secret.GetNamespace(), secret.GetName()),
+							format:        certificateFormatKubeSecret,
+							kubeSecret:    secret,
+							kubeSecretKey: key,
+						})
+					}
 				}
 			}
 		}
@@ -247,17 +247,12 @@ func (exporter *Exporter) filterSecrets(secrets []v1.Secret, includedLabels, exc
 
 func (exporter *Exporter) checkHasIncludedType(secret *v1.Secret) (bool, error) {
 	for _, secretType := range exporter.KubeSecretTypes {
-		typeAndKey := strings.Split(secretType, ":")
-
-		if len(typeAndKey) != 2 {
-			return false, fmt.Errorf("malformed kube secret type: \"%s\"", secretType)
-		}
-
-		if secret.Type == v1.SecretType(typeAndKey[0]) && len(secret.Data[typeAndKey[1]]) > 0 {
-			return true, nil
+		for key := range secret.Data {
+			if secretType.Matches(string(secret.Type), key) {
+				return true, nil
+			}
 		}
 	}
-
 	return false, nil
 }
 
@@ -272,9 +267,10 @@ func (exporter *Exporter) shrinkSecret(secret v1.Secret) v1.Secret {
 	}
 
 	for _, secretType := range exporter.KubeSecretTypes {
-		typeAndKey := strings.Split(secretType, ":")
-		if secret.Type == v1.SecretType(typeAndKey[0]) && len(secret.Data[typeAndKey[1]]) > 0 {
-			result.Data[typeAndKey[1]] = secret.Data[typeAndKey[1]]
+		for key := range secret.Data {
+			if secretType.Matches(string(secret.Type), key) {
+				result.Data[key] = secret.Data[key]
+			}
 		}
 	}
 

--- a/internal/kubernetes.go
+++ b/internal/kubernetes.go
@@ -248,7 +248,7 @@ func (exporter *Exporter) filterSecrets(secrets []v1.Secret, includedLabels, exc
 func (exporter *Exporter) checkHasIncludedType(secret *v1.Secret) (bool, error) {
 	for _, secretType := range exporter.KubeSecretTypes {
 		for key := range secret.Data {
-			if secretType.Matches(string(secret.Type), key) {
+			if len(secret.Data[key]) > 0 && secretType.Matches(string(secret.Type), key) {
 				return true, nil
 			}
 		}
@@ -268,7 +268,7 @@ func (exporter *Exporter) shrinkSecret(secret v1.Secret) v1.Secret {
 
 	for _, secretType := range exporter.KubeSecretTypes {
 		for key := range secret.Data {
-			if secretType.Matches(string(secret.Type), key) {
+			if len(secret.Data[key]) > 0 && secretType.Matches(string(secret.Type), key) {
 				result.Data[key] = secret.Data[key]
 			}
 		}

--- a/internal/kubernetes_test.go
+++ b/internal/kubernetes_test.go
@@ -364,7 +364,7 @@ func TestKubeEmptyStringKey(t *testing.T) {
 		},
 	}, func(m []model.MetricFamily) {
 		metrics := getMetricsForName(m, "x509_read_errors")
-		assert.Equal(t, 0., metrics[0].GetGauge().GetValue())
+		assert.Equal(t, 1., metrics[0].GetGauge().GetValue())
 	})
 }
 

--- a/internal/kubernetes_test.go
+++ b/internal/kubernetes_test.go
@@ -364,7 +364,7 @@ func TestKubeEmptyStringKey(t *testing.T) {
 		},
 	}, func(m []model.MetricFamily) {
 		metrics := getMetricsForName(m, "x509_read_errors")
-		assert.Equal(t, 1., metrics[0].GetGauge().GetValue())
+		assert.Equal(t, 0., metrics[0].GetGauge().GetValue())
 	})
 }
 


### PR DESCRIPTION
Hi,

this is an implementation for 242, because #243 seems a bit inactive. There are two notable changes:
- dots in file names need to be escaped, due to their special meaning in regex patterns
- the read errors metric behaves differently