### PR TITLE
fix: shrinkSecret to actually shrink

### DIFF
--- a/internal/kubernetes.go
+++ b/internal/kubernetes.go
@@ -230,7 +230,7 @@ func (exporter *Exporter) shrinkSecret(secret v1.Secret) v1.Secret {
 		}
 	}
 
-	return secret
+	return result
 }
 
 func connectToKubernetesCluster(kubeconfigPath string, insecure bool, rateLimiter flowcontrol.RateLimiter) (*kubernetes.Clientset, error) {


### PR DESCRIPTION
Currently `shrinkSecret` is only spending CPU cycles and returning the input object unchanged. Fix to return the shrunk object

May help a little with memory usage