### PR TITLE
Add feature to parse both pkcs12 truststore and keystore formats

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ __pycache__
 *.debug
 coverage.html
 /kubeconfig*
+p12-passwords.yml
+/x509-certificate-exporter

--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,5 @@ __pycache__
 *.debug
 coverage.html
 /kubeconfig*
-p12-passwords.yml
+passwords.yml
 /x509-certificate-exporter

--- a/cmd/x509-certificate-exporter/main.go
+++ b/cmd/x509-certificate-exporter/main.go
@@ -75,8 +75,8 @@ func main() {
 	kubeExcludeLabels := stringArrayFlag{}
 	getopt.FlagLong(&kubeExcludeLabels, "exclude-label", 0, "removes the kube secrets with the given label (or label value if specified) from the watch list (applied after --include-label)")
 
-        var p12PasswordsFile string
-        getopt.FlagLong(&p12PasswordsFile, "p12-passwords-file", 0, "path to a yaml file containing a list of passwords to try when opening a p12 file")
+        var PasswordsFile string
+        getopt.FlagLong(&PasswordsFile, "passwords-file", 0, "path to a yaml file containing a list of passwords to try when opening a p12 file")
 
 	getopt.Parse()
 
@@ -148,7 +148,7 @@ func main() {
 		KubeExcludeNamespaces: kubeExcludeNamespaces,
 		KubeIncludeLabels:     kubeIncludeLabels,
 		KubeExcludeLabels:     kubeExcludeLabels,
-                P12PasswordsFile:      p12PasswordsFile,
+                PasswordsFile:      PasswordsFile,
 	}
 
 	if getopt.Lookup("expose-labels").Seen() {

--- a/cmd/x509-certificate-exporter/main.go
+++ b/cmd/x509-certificate-exporter/main.go
@@ -75,8 +75,8 @@ func main() {
 	kubeExcludeLabels := stringArrayFlag{}
 	getopt.FlagLong(&kubeExcludeLabels, "exclude-label", 0, "removes the kube secrets with the given label (or label value if specified) from the watch list (applied after --include-label)")
 
-        var PasswordsFile string
-        getopt.FlagLong(&PasswordsFile, "passwords-file", 0, "path to a yaml file containing a list of passwords to try when opening a p12 file")
+	var PasswordsFile string
+	getopt.FlagLong(&PasswordsFile, "passwords-file", 0, "path to a yaml file containing a list of passwords to try when opening a p12 file")
 
 	getopt.Parse()
 
@@ -148,7 +148,7 @@ func main() {
 		KubeExcludeNamespaces: kubeExcludeNamespaces,
 		KubeIncludeLabels:     kubeIncludeLabels,
 		KubeExcludeLabels:     kubeExcludeLabels,
-                PasswordsFile:      PasswordsFile,
+		PasswordsFile:         PasswordsFile,
 	}
 
 	if getopt.Lookup("expose-labels").Seen() {

--- a/cmd/x509-certificate-exporter/main.go
+++ b/cmd/x509-certificate-exporter/main.go
@@ -75,6 +75,9 @@ func main() {
 	kubeExcludeLabels := stringArrayFlag{}
 	getopt.FlagLong(&kubeExcludeLabels, "exclude-label", 0, "removes the kube secrets with the given label (or label value if specified) from the watch list (applied after --include-label)")
 
+        var p12PasswordsFile string
+        getopt.FlagLong(&p12PasswordsFile, "p12-passwords-file", 0, "path to a yaml file containing a list of passwords to try when opening a p12 file")
+
 	getopt.Parse()
 
 	if *help {
@@ -145,6 +148,7 @@ func main() {
 		KubeExcludeNamespaces: kubeExcludeNamespaces,
 		KubeIncludeLabels:     kubeIncludeLabels,
 		KubeExcludeLabels:     kubeExcludeLabels,
+                P12PasswordsFile:      p12PasswordsFile,
 	}
 
 	if getopt.Lookup("expose-labels").Seen() {

--- a/go.mod
+++ b/go.mod
@@ -78,7 +78,6 @@ require (
 	sigs.k8s.io/json v0.0.0-20241014173422-cfa47c3a1cc8 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.2 // indirect
 	sigs.k8s.io/yaml v1.4.0 // indirect
-	software.sslmate.com/src/go-pkcs12 v0.4.0 // indirect
 )
 
 replace github.com/bmatcuk/doublestar/v4 => github.com/enix/doublestar/v4 v4.0.0-20230517083426-fa6d1b0d071d

--- a/go.mod
+++ b/go.mod
@@ -16,10 +16,12 @@ require (
 	github.com/stretchr/testify v1.10.0
 	github.com/yalp/jsonpath v0.0.0-20180802001716-5cc68e5049a0
 	go.uber.org/automaxprocs v1.6.0
+	gopkg.in/yaml.v2 v2.4.0
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.32.0
 	k8s.io/apimachinery v0.32.0
 	k8s.io/client-go v0.32.0
+	software.sslmate.com/src/go-pkcs12 v0.5.0
 )
 
 require (

--- a/go.mod
+++ b/go.mod
@@ -78,10 +78,9 @@ require (
 	sigs.k8s.io/json v0.0.0-20241014173422-cfa47c3a1cc8 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.2 // indirect
 	sigs.k8s.io/yaml v1.4.0 // indirect
+	software.sslmate.com/src/go-pkcs12 v0.4.0 // indirect
 )
 
 replace github.com/bmatcuk/doublestar/v4 => github.com/enix/doublestar/v4 v4.0.0-20230517083426-fa6d1b0d071d
 
 replace github.com/imdario/mergo => github.com/imdario/mergo v0.3.16
-
-replace software.sslmate.com/src/go-pkcs12 => github.com/muhammadn/go-pkcs12 v0.0.0-20240726114946-df1b7d811158

--- a/go.mod
+++ b/go.mod
@@ -72,16 +72,16 @@ require (
 	google.golang.org/protobuf v1.35.2 // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
-	gopkg.in/yaml.v2 v2.4.0 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20241105132330-32ad38e42d3f // indirect
 	k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738 // indirect
 	sigs.k8s.io/json v0.0.0-20241014173422-cfa47c3a1cc8 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.2 // indirect
 	sigs.k8s.io/yaml v1.4.0 // indirect
-	software.sslmate.com/src/go-pkcs12 v0.4.0 // indirect
 )
 
 replace github.com/bmatcuk/doublestar/v4 => github.com/enix/doublestar/v4 v4.0.0-20230517083426-fa6d1b0d071d
 
 replace github.com/imdario/mergo => github.com/imdario/mergo v0.3.16
+
+replace software.sslmate.com/src/go-pkcs12 => github.com/muhammadn/go-pkcs12 v0.0.0-20240726114946-df1b7d811158

--- a/go.mod
+++ b/go.mod
@@ -79,6 +79,7 @@ require (
 	sigs.k8s.io/json v0.0.0-20241014173422-cfa47c3a1cc8 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.2 // indirect
 	sigs.k8s.io/yaml v1.4.0 // indirect
+	software.sslmate.com/src/go-pkcs12 v0.4.0 // indirect
 )
 
 replace github.com/bmatcuk/doublestar/v4 => github.com/enix/doublestar/v4 v4.0.0-20230517083426-fa6d1b0d071d

--- a/go.sum
+++ b/go.sum
@@ -218,3 +218,5 @@ sigs.k8s.io/structured-merge-diff/v4 v4.4.2 h1:MdmvkGuXi/8io6ixD5wud3vOLwc1rj0aN
 sigs.k8s.io/structured-merge-diff/v4 v4.4.2/go.mod h1:N8f93tFZh9U6vpxwRArLiikrE5/2tiu1w1AGfACIGE4=
 sigs.k8s.io/yaml v1.4.0 h1:Mk1wCc2gy/F0THH0TAp1QYyJNzRm2KCLy3o5ASXVI5E=
 sigs.k8s.io/yaml v1.4.0/go.mod h1:Ejl7/uTz7PSA4eKMyQCUTnhZYNmLIl+5c2lQPGR2BPY=
+software.sslmate.com/src/go-pkcs12 v0.4.0 h1:H2g08FrTvSFKUj+D309j1DPfk5APnIdAQAB8aEykJ5k=
+software.sslmate.com/src/go-pkcs12 v0.4.0/go.mod h1:Qiz0EyvDRJjjxGyUQa2cCNZn/wMyzrRJ/qcDXOQazLI=

--- a/go.sum
+++ b/go.sum
@@ -218,5 +218,5 @@ sigs.k8s.io/structured-merge-diff/v4 v4.4.2 h1:MdmvkGuXi/8io6ixD5wud3vOLwc1rj0aN
 sigs.k8s.io/structured-merge-diff/v4 v4.4.2/go.mod h1:N8f93tFZh9U6vpxwRArLiikrE5/2tiu1w1AGfACIGE4=
 sigs.k8s.io/yaml v1.4.0 h1:Mk1wCc2gy/F0THH0TAp1QYyJNzRm2KCLy3o5ASXVI5E=
 sigs.k8s.io/yaml v1.4.0/go.mod h1:Ejl7/uTz7PSA4eKMyQCUTnhZYNmLIl+5c2lQPGR2BPY=
-software.sslmate.com/src/go-pkcs12 v0.4.0 h1:H2g08FrTvSFKUj+D309j1DPfk5APnIdAQAB8aEykJ5k=
-software.sslmate.com/src/go-pkcs12 v0.4.0/go.mod h1:Qiz0EyvDRJjjxGyUQa2cCNZn/wMyzrRJ/qcDXOQazLI=
+software.sslmate.com/src/go-pkcs12 v0.5.0 h1:EC6R394xgENTpZ4RltKydeDUjtlM5drOYIG9c6TVj2M=
+software.sslmate.com/src/go-pkcs12 v0.5.0/go.mod h1:Qiz0EyvDRJjjxGyUQa2cCNZn/wMyzrRJ/qcDXOQazLI=

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,6 @@ github.com/KimMachineGun/automemlimit v0.6.1 h1:ILa9j1onAAMadBsyyUJv5cack8Y1WT26
 github.com/KimMachineGun/automemlimit v0.6.1/go.mod h1:T7xYht7B8r6AG/AqFcUdc7fzd2bIdBKmepfP2S1svPY=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
-github.com/bitrise-io/go-pkcs12 v0.0.0-20230913085202-b40653eb06c7 h1:UgbAP2//OniQV9K5tHg7jnPfSYAy5ujXyH6E7L7CTBQ=
-github.com/bitrise-io/go-pkcs12 v0.0.0-20230913085202-b40653eb06c7/go.mod h1:fly5xmzjteedkhq4NJiEFbtC6KjvFdNeFxaTw2yF//k=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cilium/ebpf v0.16.0 h1:+BiEnHL6Z7lXnlGUsXQPPAE7+kenAd4ES8MQ5min0Ok=
@@ -88,8 +86,6 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9Gz0M=
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
-github.com/muhammadn/go-pkcs12 v0.0.0-20240726114946-df1b7d811158 h1:/PeM8Ldp2xJXka5S8eIFqNjUl6WR6er6NmMv99zMffM=
-github.com/muhammadn/go-pkcs12 v0.0.0-20240726114946-df1b7d811158/go.mod h1:Qiz0EyvDRJjjxGyUQa2cCNZn/wMyzrRJ/qcDXOQazLI=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f h1:KUppIJq7/+SVif2QVs3tOP0zanoHgBEVAwHxUSIzRqU=

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/KimMachineGun/automemlimit v0.6.1 h1:ILa9j1onAAMadBsyyUJv5cack8Y1WT26
 github.com/KimMachineGun/automemlimit v0.6.1/go.mod h1:T7xYht7B8r6AG/AqFcUdc7fzd2bIdBKmepfP2S1svPY=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
+github.com/bitrise-io/go-pkcs12 v0.0.0-20230913085202-b40653eb06c7 h1:UgbAP2//OniQV9K5tHg7jnPfSYAy5ujXyH6E7L7CTBQ=
+github.com/bitrise-io/go-pkcs12 v0.0.0-20230913085202-b40653eb06c7/go.mod h1:fly5xmzjteedkhq4NJiEFbtC6KjvFdNeFxaTw2yF//k=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cilium/ebpf v0.16.0 h1:+BiEnHL6Z7lXnlGUsXQPPAE7+kenAd4ES8MQ5min0Ok=
@@ -220,3 +222,5 @@ sigs.k8s.io/structured-merge-diff/v4 v4.4.2 h1:MdmvkGuXi/8io6ixD5wud3vOLwc1rj0aN
 sigs.k8s.io/structured-merge-diff/v4 v4.4.2/go.mod h1:N8f93tFZh9U6vpxwRArLiikrE5/2tiu1w1AGfACIGE4=
 sigs.k8s.io/yaml v1.4.0 h1:Mk1wCc2gy/F0THH0TAp1QYyJNzRm2KCLy3o5ASXVI5E=
 sigs.k8s.io/yaml v1.4.0/go.mod h1:Ejl7/uTz7PSA4eKMyQCUTnhZYNmLIl+5c2lQPGR2BPY=
+software.sslmate.com/src/go-pkcs12 v0.4.0 h1:H2g08FrTvSFKUj+D309j1DPfk5APnIdAQAB8aEykJ5k=
+software.sslmate.com/src/go-pkcs12 v0.4.0/go.mod h1:Qiz0EyvDRJjjxGyUQa2cCNZn/wMyzrRJ/qcDXOQazLI=

--- a/go.sum
+++ b/go.sum
@@ -86,6 +86,8 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9Gz0M=
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
+github.com/muhammadn/go-pkcs12 v0.0.0-20240726114946-df1b7d811158 h1:/PeM8Ldp2xJXka5S8eIFqNjUl6WR6er6NmMv99zMffM=
+github.com/muhammadn/go-pkcs12 v0.0.0-20240726114946-df1b7d811158/go.mod h1:Qiz0EyvDRJjjxGyUQa2cCNZn/wMyzrRJ/qcDXOQazLI=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f h1:KUppIJq7/+SVif2QVs3tOP0zanoHgBEVAwHxUSIzRqU=
@@ -218,5 +220,3 @@ sigs.k8s.io/structured-merge-diff/v4 v4.4.2 h1:MdmvkGuXi/8io6ixD5wud3vOLwc1rj0aN
 sigs.k8s.io/structured-merge-diff/v4 v4.4.2/go.mod h1:N8f93tFZh9U6vpxwRArLiikrE5/2tiu1w1AGfACIGE4=
 sigs.k8s.io/yaml v1.4.0 h1:Mk1wCc2gy/F0THH0TAp1QYyJNzRm2KCLy3o5ASXVI5E=
 sigs.k8s.io/yaml v1.4.0/go.mod h1:Ejl7/uTz7PSA4eKMyQCUTnhZYNmLIl+5c2lQPGR2BPY=
-software.sslmate.com/src/go-pkcs12 v0.4.0 h1:H2g08FrTvSFKUj+D309j1DPfk5APnIdAQAB8aEykJ5k=
-software.sslmate.com/src/go-pkcs12 v0.4.0/go.mod h1:Qiz0EyvDRJjjxGyUQa2cCNZn/wMyzrRJ/qcDXOQazLI=

--- a/internal/certificate.go
+++ b/internal/certificate.go
@@ -14,6 +14,7 @@ import (
 	"github.com/yalp/jsonpath"
 	"gopkg.in/yaml.v3"
 	v1 "k8s.io/api/core/v1"
+	"software.sslmate.com/src/go-pkcs12"
 )
 
 // YAMLCertRef : Contains information to access certificates in yaml files
@@ -69,6 +70,8 @@ type certificateRef struct {
 	kubeSecret    v1.Secret
 	kubeConfigMap v1.ConfigMap
 	kubeSecretKey string
+	p12Password   string
+
 }
 
 type parsedCertificate struct {
@@ -89,6 +92,7 @@ const (
 	certificateFormatYAML                            = iota
 	certificateFormatKubeSecret                      = iota
 	certificateFormatKubeConfigMap                   = iota
+	certificateFormatP12                          = iota
 )
 
 func (cert *certificateRef) parse() error {
@@ -103,6 +107,8 @@ func (cert *certificateRef) parse() error {
 		cert.certificates, err = readAndParseKubeSecret(&cert.kubeSecret, cert.kubeSecretKey)
 	case certificateFormatKubeConfigMap:
 		cert.certificates, err = readAndParseKubeConfigMap(&cert.kubeConfigMap, cert.kubeSecretKey)
+	case certificateFormatP12:
+		cert.certificates, err = readAndParsePasswordPkcsFile(cert.path, cert.p12Password)
 	}
 	return err
 }
@@ -124,6 +130,22 @@ func readAndParsePEMFile(path string) ([]*parsedCertificate, error) {
 	}
 
 	return output, nil
+}
+
+func readAndParsePasswordPkcsFile(path string, password string) ([]*parsedCertificate, error) {
+        contents, err := readFile(path)
+       if err != nil {
+               return nil, err
+       }
+
+       output := []*parsedCertificate{}
+       _, cert, err := pkcs12.Decode(contents, password)
+        if err != nil {
+               return nil, err
+       }
+
+       output = append(output, &parsedCertificate{cert: cert})
+       return output, nil
 }
 
 func readAndParseYAMLFile(filePath string, yamlPaths []YAMLCertRef) ([]*parsedCertificate, error) {

--- a/internal/certificate.go
+++ b/internal/certificate.go
@@ -134,18 +134,28 @@ func readAndParsePEMFile(path string) ([]*parsedCertificate, error) {
 
 func readAndParsePasswordPkcsFile(path string, password string) ([]*parsedCertificate, error) {
         contents, err := readFile(path)
-       if err != nil {
-               return nil, err
-       }
-
-       output := []*parsedCertificate{}
-       _, cert, err := pkcs12.Decode(contents, password)
         if err != nil {
                return nil, err
-       }
+        }
 
-       output = append(output, &parsedCertificate{cert: cert})
-       return output, nil
+        output := []*parsedCertificate{}
+        // keystore p12
+        _, cert, err := pkcs12.Decode(contents, password)
+	if err == nil {
+                output = append(output, &parsedCertificate{cert: cert})
+		return output, nil
+	}
+
+	// truststore p12
+        certs, err := pkcs12.DecodeTrustStore(contents, password)
+        if err != nil {
+                return nil, err
+        }
+
+        for _, cert := range certs {
+                output = append(output, &parsedCertificate{cert: cert})
+        }
+        return output, nil
 }
 
 func readAndParseYAMLFile(filePath string, yamlPaths []YAMLCertRef) ([]*parsedCertificate, error) {

--- a/internal/certificate.go
+++ b/internal/certificate.go
@@ -70,7 +70,7 @@ type certificateRef struct {
 	kubeSecret    v1.Secret
 	kubeConfigMap v1.ConfigMap
 	kubeSecretKey string
-	p12Password   string
+	password   string
 
 }
 
@@ -108,7 +108,7 @@ func (cert *certificateRef) parse() error {
 	case certificateFormatKubeConfigMap:
 		cert.certificates, err = readAndParseKubeConfigMap(&cert.kubeConfigMap, cert.kubeSecretKey)
 	case certificateFormatP12:
-		cert.certificates, err = readAndParsePasswordPkcsFile(cert.path, cert.p12Password)
+		cert.certificates, err = readAndParsePasswordPkcsFile(cert.path, cert.password)
 	}
 	return err
 }

--- a/internal/exporter.go
+++ b/internal/exporter.go
@@ -357,11 +357,11 @@ func (exporter *Exporter) collectMatchingPaths(pattern string, format certificat
 
 func (exporter *Exporter) obtainP12Passwords(filename string) (string, error) {
         filename = filepath.Base(filename)
-        if len(exporter.p12PasswordsFile) == 0 {
+        if len(exporter.P12PasswordsFile) == 0 {
                 return "", errors.New("p12 password file not specified")
         }
 
-        passwordsFile, err := os.ReadFile(exporter.p12PasswordsFile)
+        passwordsFile, err := os.ReadFile(exporter.P12PasswordsFile)
         if err != nil {
                 return "", err
         }

--- a/internal/exporter.go
+++ b/internal/exporter.go
@@ -296,11 +296,13 @@ func (exporter *Exporter) collectMatchingPaths(pattern string, format certificat
                                                 continue
                                         }
                                 } else {
-					if strings.HasSuffix(file.Name(), ".key") {
-                                        	continue
-					}
-
-                                        format = certificateFormatPEM
+					if strings.HasSuffix(file.Name(), ".crt") ||
+					   strings.HasSuffix(file.Name(), ".pem") || 
+					   strings.HasSuffix(file.Name(), ".cert") {
+						format = certificateFormatPEM
+					} else {
+                                                continue
+                                        }
                                 }
 
 				output = append(output, &certificateRef{

--- a/internal/exporter.go
+++ b/internal/exporter.go
@@ -357,11 +357,11 @@ func (exporter *Exporter) collectMatchingPaths(pattern string, format certificat
 
 func (exporter *Exporter) obtainP12Passwords(filename string) (string, error) {
         filename = filepath.Base(filename)
-        if len(exporter.P12PasswordsFile) == 0 {
-                return "", errors.New("p12 password file not specified")
+        if len(exporter.PasswordsFile) == 0 {
+                return "", errors.New("password file not specified")
         }
 
-        passwordsFile, err := os.ReadFile(exporter.P12PasswordsFile)
+        passwordsFile, err := os.ReadFile(exporter.PasswordsFile)
         if err != nil {
                 return "", err
         }

--- a/internal/exporter.go
+++ b/internal/exporter.go
@@ -22,8 +22,8 @@ import (
 
 	"github.com/bmatcuk/doublestar/v4"
 	"github.com/prometheus/exporter-toolkit/web"
+	"gopkg.in/yaml.v2"
 	"k8s.io/client-go/kubernetes"
-        "gopkg.in/yaml.v2"
 )
 
 // Exporter : Configuration (from command-line)
@@ -53,7 +53,7 @@ type Exporter struct {
 	isDiscovery     bool
 	secretsCache    *cache.Cache
 	configMapsCache *cache.Cache
-        p12PasswordsFile string
+    PasswordsFile string
 }
 
 type KubeSecretType struct {
@@ -297,7 +297,7 @@ func (exporter *Exporter) collectMatchingPaths(pattern string, format certificat
                                         }
                                 } else {
 					if strings.HasSuffix(file.Name(), ".crt") ||
-					   strings.HasSuffix(file.Name(), ".pem") || 
+					   strings.HasSuffix(file.Name(), ".pem") ||
 					   strings.HasSuffix(file.Name(), ".cert") {
 						format = certificateFormatPEM
 					} else {
@@ -382,13 +382,13 @@ func (exporter *Exporter) obtainP12Passwords(filename string) (string, error) {
         if err = yaml.Unmarshal(passwordsFile, &config); err != nil {
                 return "", err
         }
- 
+
         for _, p12 := range config.P12 {
                 if p12.Name == filename {
                         return p12.Password, nil
                 }
          }
-  
+
         return "", errors.New("p12 password not found")
 }
 

--- a/internal/exporter.go
+++ b/internal/exporter.go
@@ -287,10 +287,10 @@ func (exporter *Exporter) collectMatchingPaths(pattern string, format certificat
 					continue
 				}
 
-                                var p12Password string
+                                var password string
                                 if strings.HasSuffix(file.Name(), ".p12") || strings.HasSuffix(file.Name(), ".jks") {
                                         format = certificateFormatP12
-                                        p12Password, err = exporter.obtainP12Passwords(path.Clean(path.Join(dir, file.Name())))
+                                        password, err = exporter.obtainP12Passwords(path.Clean(path.Join(dir, file.Name())))
                                         if err != nil {
                                                 outputErrors = append(outputErrors, err)
                                                 continue
@@ -302,7 +302,7 @@ func (exporter *Exporter) collectMatchingPaths(pattern string, format certificat
 				output = append(output, &certificateRef{
                                         path:        path.Clean(path.Join(dir, file.Name())),
                                         format:      format,
-                                        p12Password: p12Password,
+                                        password:    password,
 				})
 			}
 		} else {

--- a/internal/exporter.go
+++ b/internal/exporter.go
@@ -296,7 +296,11 @@ func (exporter *Exporter) collectMatchingPaths(pattern string, format certificat
                                                 continue
                                         }
                                 } else {
-                                         format = certificateFormatPEM
+					if strings.HasSuffix(file.Name(), ".key") {
+                                        	continue
+					}
+
+                                        format = certificateFormatPEM
                                 }
 
 				output = append(output, &certificateRef{

--- a/internal/exporter.go
+++ b/internal/exporter.go
@@ -370,7 +370,7 @@ func (exporter *Exporter) obtainP12Passwords(filename string) (string, error) {
                 Password string `yaml:"password"`
         }
         type Config struct {
-                P12 []P12Config `yaml:"p12"`
+                P12 []P12Config `yaml:"pkcs12"`
         }
         var config Config
         if err = yaml.Unmarshal(passwordsFile, &config); err != nil {

--- a/internal/exporter.go
+++ b/internal/exporter.go
@@ -288,7 +288,7 @@ func (exporter *Exporter) collectMatchingPaths(pattern string, format certificat
 				}
 
                                 var p12Password string
-                                if strings.HasSuffix(file.Name(), ".p12") {
+                                if strings.HasSuffix(file.Name(), ".p12") || strings.HasSuffix(file.Name(), ".jks") {
                                         format = certificateFormatP12
                                         p12Password, err = exporter.obtainP12Passwords(path.Clean(path.Join(dir, file.Name())))
                                         if err != nil {

--- a/passwords.yml.example
+++ b/passwords.yml.example
@@ -1,0 +1,6 @@
+---
+p12:
+  - name: "keystore.p12"
+    password: "mysecretpassword1"
+  - name: "truststore.p12"
+    password: "mysecretpassword2"

--- a/passwords.yml.example
+++ b/passwords.yml.example
@@ -1,5 +1,5 @@
 ---
-p12:
+pkcs12:
   - name: "keystore.p12"
     password: "mysecretpassword1"
   - name: "truststore.p12"


### PR DESCRIPTION
Currently, no other implementations, even https://github.com/joe-elliott/cert-exporter supports reading both keystore and truststore.

This feature adds in that functionality to read password protected pkcs12 containers and read both keystore and truststore certificates for monitoring of expiring certificates.