### PR TITLE
Allow reading certificates from `ConfigMap` resources

### DIFF
--- a/cmd/x509-certificate-exporter/main.go
+++ b/cmd/x509-certificate-exporter/main.go
@@ -35,6 +35,7 @@ func main() {
 	exposeRelativeMetrics := getopt.BoolLong("expose-relative-metrics", 0, "expose additionnal metrics with relative durations instead of absolute timestamps")
 	exposeErrorMetrics := getopt.BoolLong("expose-per-cert-error-metrics", 0, "expose additionnal error metric for each certificate indicating wether it has failure(s)")
 	exposeLabels := getopt.StringLong("expose-labels", 'l', "one or more comma-separated labels to enable (defaults to all if not specified)")
+	exposeConfigMapLabels := getopt.StringLong("expose-configmap-labels", 0, "one or more comma-separated labels to enable (defaults to all if not specified)")
 	profile := getopt.BoolLong("profile", 0, "optionally enable a pprof server to monitor cpu and memory usage at runtime")
 
 	maxCacheDuration := durationFlag(0)
@@ -58,6 +59,9 @@ func main() {
 
 	kubeSecretTypes := stringArrayFlag{}
 	getopt.FlagLong(&kubeSecretTypes, "secret-type", 's', "one or more kubernetes secret type & key to watch (e.g. \"kubernetes.io/tls:tls.crt\"")
+
+	kubeConfigMapKeys := stringArrayFlag{}
+	getopt.FlagLong(&kubeConfigMapKeys, "configmap-keys", 'c', "keys in configmaps to watch")
 
 	kubeIncludeNamespaces := stringArrayFlag{}
 	getopt.FlagLong(&kubeIncludeNamespaces, "include-namespace", 0, "add the given kube namespace to the watch list (when used, all namespaces are excluded by default)")
@@ -112,6 +116,7 @@ func main() {
 		ExposeRelativeMetrics: *exposeRelativeMetrics,
 		ExposeErrorMetrics:    *exposeErrorMetrics,
 		KubeSecretTypes:       kubeSecretTypes,
+		ConfigMapKeys:         kubeConfigMapKeys,
 		KubeIncludeNamespaces: kubeIncludeNamespaces,
 		KubeExcludeNamespaces: kubeExcludeNamespaces,
 		KubeIncludeLabels:     kubeIncludeLabels,
@@ -120,6 +125,9 @@ func main() {
 
 	if getopt.Lookup("expose-labels").Seen() {
 		exporter.ExposeLabels = strings.Split(*exposeLabels, ",")
+	}
+	if getopt.Lookup("expose-configmap-labels").Seen() {
+		exporter.ExposeConfigMapLabels = strings.Split(*exposeConfigMapLabels, ",")
 	}
 
 	if *kubeEnabled {

--- a/cmd/x509-certificate-exporter/main.go
+++ b/cmd/x509-certificate-exporter/main.go
@@ -35,7 +35,6 @@ func main() {
 	exposeRelativeMetrics := getopt.BoolLong("expose-relative-metrics", 0, "expose additionnal metrics with relative durations instead of absolute timestamps")
 	exposeErrorMetrics := getopt.BoolLong("expose-per-cert-error-metrics", 0, "expose additionnal error metric for each certificate indicating wether it has failure(s)")
 	exposeLabels := getopt.StringLong("expose-labels", 'l', "one or more comma-separated labels to enable (defaults to all if not specified)")
-	exposeConfigMapLabels := getopt.StringLong("expose-configmap-labels", 0, "one or more comma-separated labels to enable (defaults to all if not specified)")
 	profile := getopt.BoolLong("profile", 0, "optionally enable a pprof server to monitor cpu and memory usage at runtime")
 
 	maxCacheDuration := durationFlag(0)
@@ -125,9 +124,6 @@ func main() {
 
 	if getopt.Lookup("expose-labels").Seen() {
 		exporter.ExposeLabels = strings.Split(*exposeLabels, ",")
-	}
-	if getopt.Lookup("expose-configmap-labels").Seen() {
-		exporter.ExposeConfigMapLabels = strings.Split(*exposeConfigMapLabels, ",")
 	}
 
 	if *kubeEnabled {

--- a/deploy/charts/x509-certificate-exporter/README.md
+++ b/deploy/charts/x509-certificate-exporter/README.md
@@ -384,6 +384,7 @@ hostPathsExporter:
 | secretsExporter.extraVolumes | list | `[]` | Additionnal volumes added to Pods of the TLS Secrets exporter (combined with global `extraVolumes`) |
 | secretsExporter.extraVolumeMounts | list | `[]` | Additionnal volume mounts added to Pod containers of the TLS Secrets exporter (combined with global `extraVolumeMounts`) |
 | secretsExporter.secretTypes | list | check `values.yaml` | Which type of Secrets should be watched ; "key" is the map key in the secret data |
+| secretsExporter.configMapKeys | list | check `values.yaml` | If the exporter should for certificates in configmaps, just specify the keys it needs to watch. E.g.: `configMapKeys: ["tls.crt"]` |
 | secretsExporter.includeNamespaces | list | `[]` | Restrict the list of namespaces the TLS Secrets exporter should scan for certificates to watch (all namespaces if empty) |
 | secretsExporter.excludeNamespaces | list | `[]` | Exclude namespaces from being scanned by the TLS Secrets exporter (evaluated after `includeNamespaces`) |
 | secretsExporter.includeLabels | list | `[]` | Only watch TLS Secrets having these labels (all secrets if empty). Items can be keys such as `my-label` or also require a value with syntax `my-label=my-value`. |
@@ -427,7 +428,7 @@ hostPathsExporter:
 | prometheusServiceMonitor.scrapeInterval | string | `"60s"` | Target scrape interval set in the ServiceMonitor |
 | prometheusServiceMonitor.scrapeTimeout | string | `"30s"` | Target scrape timeout set in the ServiceMonitor |
 | prometheusServiceMonitor.extraLabels | object | `{}` | Additional labels to add to ServiceMonitor objects |
-| prometheusServiceMonitor.metricRelabelings | list | `[]` | Metrics relabel config for the ServiceMonitor, see: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#monitoring.coreos.com/v1.Endpoint |
+| prometheusServiceMonitor.metricRelabelings | list | `[]` | Metric relabel config for the ServiceMonitor, see: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#monitoring.coreos.com/v1.Endpoint |
 | prometheusServiceMonitor.relabelings | list | `[]` | Relabel config for the ServiceMonitor, see: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#monitoring.coreos.com/v1.Endpoint |
 | prometheusPodMonitor.create | bool | `false` | Should a PodMonitor object be installed to scrape this exporter. For prometheus-operator (kube-prometheus) users. |
 | prometheusPodMonitor.scrapeInterval | string | `"60s"` | Target scrape interval set in the PodMonitor |

--- a/deploy/charts/x509-certificate-exporter/templates/clusterrole.yaml
+++ b/deploy/charts/x509-certificate-exporter/templates/clusterrole.yaml
@@ -28,6 +28,16 @@ rules:
   - get
   - watch
   - list
+{{- if .Values.secretsExporter.configMapKeys }}
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - watch
+  - list
+{{- end }}
 {{- if .Values.rbacProxy.enable }}
 - apiGroups:
   - authentication.k8s.io

--- a/deploy/charts/x509-certificate-exporter/templates/deployment.yaml
+++ b/deploy/charts/x509-certificate-exporter/templates/deployment.yaml
@@ -105,6 +105,9 @@ spec:
         {{- range .Values.secretsExporter.secretTypes }}
         - --secret-type={{ .type | trim }}:{{ .key | trim }}
         {{- end }}
+        {{- range .Values.secretsExporter.configMapKeys }}
+        - --secret-type={{ . | trim }}
+        {{- end }}
         {{- range .Values.secretsExporter.includeNamespaces }}
         - --include-namespace={{ . | trim }}
         {{- end }}

--- a/deploy/charts/x509-certificate-exporter/templates/deployment.yaml
+++ b/deploy/charts/x509-certificate-exporter/templates/deployment.yaml
@@ -106,7 +106,7 @@ spec:
         - --secret-type={{ .type | trim }}:{{ .key | trim }}
         {{- end }}
         {{- range .Values.secretsExporter.configMapKeys }}
-        - --secret-type={{ . | trim }}
+        - --configmap-keys={{ . | trim }}
         {{- end }}
         {{- range .Values.secretsExporter.includeNamespaces }}
         - --include-namespace={{ . | trim }}

--- a/deploy/charts/x509-certificate-exporter/values.yaml
+++ b/deploy/charts/x509-certificate-exporter/values.yaml
@@ -114,6 +114,11 @@ secretsExporter:
   - type: kubernetes.io/tls
     key: tls.crt
 
+  # -- If the exporter should for certificates in configmaps, just specify the keys it needs to watch
+  # -- E.g.: `configMapKeys: ["tls.crt"]`
+  # @default -- check `values.yaml`
+  configMapKeys: []
+
   # -- Restrict the list of namespaces the TLS Secrets exporter should scan for certificates to watch (all namespaces if empty)
   includeNamespaces: []
   # -- Exclude namespaces from being scanned by the TLS Secrets exporter (evaluated after `includeNamespaces`)

--- a/deploy/charts/x509-certificate-exporter/values.yaml
+++ b/deploy/charts/x509-certificate-exporter/values.yaml
@@ -114,8 +114,7 @@ secretsExporter:
   - type: kubernetes.io/tls
     key: tls.crt
 
-  # -- If the exporter should for certificates in configmaps, just specify the keys it needs to watch
-  # -- E.g.: `configMapKeys: ["tls.crt"]`
+  # -- If the exporter should for certificates in configmaps, just specify the keys it needs to watch. E.g.: `configMapKeys: ["tls.crt"]`
   # @default -- check `values.yaml`
   configMapKeys: []
 

--- a/internal/exporter.go
+++ b/internal/exporter.go
@@ -40,16 +40,19 @@ type Exporter struct {
 	ExposeErrorMetrics    bool
 	ExposeLabels          []string
 	KubeSecretTypes       []string
+	ExposeConfigMapLabels []string
+	ConfigMapKeys         []string
 	KubeIncludeNamespaces []string
 	KubeExcludeNamespaces []string
 	KubeIncludeLabels     []string
 	KubeExcludeLabels     []string
 
-	kubeClient   *kubernetes.Clientset
-	listener     net.Listener
-	server       *http.Server
-	isDiscovery  bool
-	secretsCache *cache.Cache
+	kubeClient      *kubernetes.Clientset
+	listener        net.Listener
+	server          *http.Server
+	isDiscovery     bool
+	secretsCache    *cache.Cache
+	configMapsCache *cache.Cache
 }
 
 // ListenAndServe : Convenience function to start exporter
@@ -117,6 +120,7 @@ func (exporter *Exporter) Shutdown() error {
 // DiscoverCertificates : Parse all certs in a dry run with verbose logging
 func (exporter *Exporter) DiscoverCertificates() {
 	exporter.secretsCache = cache.New(exporter.MaxCacheDuration, 5*time.Minute)
+	exporter.configMapsCache = cache.New(exporter.MaxCacheDuration, 5*time.Minute)
 	exporter.isDiscovery = true
 	certs, errs := exporter.parseAllCertificates()
 
@@ -176,7 +180,7 @@ func (exporter *Exporter) parseAllCertificates() ([]*certificateRef, []*certific
 	}
 
 	if exporter.kubeClient != nil {
-		certs, errs := exporter.parseAllKubeSecrets()
+		certs, errs := exporter.parseAllKubeObjects()
 		output = append(output, certs...)
 		for _, err := range errs {
 			raiseError(&certificateError{

--- a/internal/exporter.go
+++ b/internal/exporter.go
@@ -40,7 +40,6 @@ type Exporter struct {
 	ExposeErrorMetrics    bool
 	ExposeLabels          []string
 	KubeSecretTypes       []string
-	ExposeConfigMapLabels []string
 	ConfigMapKeys         []string
 	KubeIncludeNamespaces []string
 	KubeExcludeNamespaces []string


### PR DESCRIPTION
PR allows reading certificates from configmaps in addition to secrets.
As outlined in https://github.com/enix/x509-certificate-exporter/issues/208, this is helpful if we want to track the CA certificates for `istio` and the API certificate expirations.

I tried implementing it in a more or less similar manner to the existing code, but I am open to changing the approach.