### PR TITLE
[Close #254] feat: support custom tls config

### DIFF
--- a/deploy/charts/x509-certificate-exporter/templates/podmonitor.yaml
+++ b/deploy/charts/x509-certificate-exporter/templates/podmonitor.yaml
@@ -19,9 +19,11 @@ spec:
     scrapeTimeout: {{ .Values.prometheusPodMonitor.scrapeTimeout }}
     {{- if .Values.rbacProxy.enable }}
     bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
-    scheme: https
+    {{- end }}
+    scheme: {{ .Values.prometheusPodMonitor.scheme }}
+    {{- with .Values.prometheusPodMonitor.tlsConfig }}
     tlsConfig:
-      insecureSkipVerify: true
+    {{- . | toYaml | nindent 6 }}
     {{- end }}
     {{- with .Values.prometheusPodMonitor.metricRelabelings }}
     metricRelabelings:

--- a/deploy/charts/x509-certificate-exporter/templates/servicemonitor.yaml
+++ b/deploy/charts/x509-certificate-exporter/templates/servicemonitor.yaml
@@ -19,9 +19,11 @@ spec:
     scrapeTimeout: {{ .Values.prometheusServiceMonitor.scrapeTimeout }}
     {{- if .Values.rbacProxy.enable }}
     bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
-    scheme: https
+    {{- end }}
+    scheme: {{ .Values.prometheusServiceMonitor.scheme }}
+    {{- with .Values.prometheusServiceMonitor.tlsConfig }}
     tlsConfig:
-      insecureSkipVerify: true
+    {{- . | toYaml | nindent 6 }}
     {{- end }}
     {{- with .Values.prometheusServiceMonitor.metricRelabelings }}
     metricRelabelings:

--- a/deploy/charts/x509-certificate-exporter/values.yaml
+++ b/deploy/charts/x509-certificate-exporter/values.yaml
@@ -240,6 +240,10 @@ prometheusServiceMonitor:
   metricRelabelings: []
   # -- Relabel config for the ServiceMonitor, see: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#monitoring.coreos.com/v1.Endpoint
   relabelings: []
+  # -- Scheme config for the ServiceMonitor, see: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#monitoring.coreos.com/v1.Endpoint
+  scheme: http
+  # -- Custom TLS configuration, see: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#monitoring.coreos.com/v1.TLSConfig
+  tlsConfig: {}
 
 prometheusPodMonitor:
   # -- Should a PodMonitor object be installed to scrape this exporter. For prometheus-operator (kube-prometheus) users.
@@ -254,6 +258,10 @@ prometheusPodMonitor:
   metricRelabelings: []
   # -- Relabel config for the PodMonitor, see: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#monitoring.coreos.com/v1.Endpoint
   relabelings: []
+  # -- Scheme config for the PodMonitor, see: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#monitoring.coreos.com/v1.Endpoint
+  scheme: http
+  # -- Custom TLS configuration, see: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#monitoring.coreos.com/v1.TLSConfig
+  tlsConfig: {}
 
 prometheusRules:
   # -- Should a PrometheusRule object be installed to alert on certificate expiration. For prometheus-operator (kube-prometheus) users.


### PR DESCRIPTION
The following patch adjusts the podMonitor and serviceMonitor resource. The static configuration `tlsConfig` is replaced so that the TLS configuration can be configured individually by the user.

The option `insecureSkipVerify: true` has been removed as it is a security risk. Users also have the option of redefining the `insecureSkipVerify` property directly via `tlsConfig` if necessary. With regard to the previous rbac auth option, however, this is superfluous.

Furthermore, the schema, i.e. HTTP or HTTPS, can now be defined to tell Prometheus which protocol should be used for communication.

The following sample configuration specifies that the x509-certificate-exporter encrypts requests via HTTPS and the HTTP client must authenticate itself via HTTPS (client auth).

```yaml
prometheusServiceMonitor:
  tlsConfig:
    caFile: /etc/prometheus/tls/ca/ca.crt
    certFile: /etc/prometheus/tls/app2app/tls.crt
    keyFile: /etc/prometheus/tls/app2app/tls.key
    insecureSkipVerify: false
    serverName: prometheus-x509-certificate-exporter

prometheusPodMonitor:
  tlsConfig:
    caFile: /etc/prometheus/tls/ca/ca.crt
    certFile: /etc/prometheus/tls/app2app/tls.crt
    keyFile: /etc/prometheus/tls/app2app/tls.key
    insecureSkipVerify: false
    serverName: prometheus-x509-certificate-exporter
```

Important Note: The `serverName` attribute must correspond to the CommonName or a Subject Alternative Name (SAN) of the TLS certificate. If this is not the case, prometheus will reject the connection trying to match the IP address of the pod with the CommonName / SAN.

The client certificate and private key as well as the certificate of the certificate authorithy must be mounted additionally via the `extraVolumes` and `extraVolumeMounts` option. This configuration is not standard and must also be implemented by the user if TLS client authentication is required.