### PR TITLE
chore(charts,x509-certificate-exporter): monitor specific file extension

### DIFF
--- a/deploy/charts/x509-certificate-exporter/templates/daemonset.yaml
+++ b/deploy/charts/x509-certificate-exporter/templates/daemonset.yaml
@@ -91,6 +91,9 @@ spec:
         {{- range default $.Values.hostPathsExporter.watchDirectories $dsDef.watchDirectories }}
         - --watch-dir=/mnt/watch/dir-{{ . | clean | sha1sum }}/{{ . | clean }}
         {{- end }}
+        {{- range default $.Values.watchSpecificExtensionDirectories $dsDef.watchSpecificExtensionDirectories }}
+        - --watch-dir=/mnt/watch/dir-{{ .directory | clean | sha1sum }}/{{ .directory | clean }}/*.{{ .extension | clean }}
+        {{- end }}
         {{- range default $.Values.hostPathsExporter.watchFiles $dsDef.watchFiles }}
         - --watch-file=/mnt/watch/file-{{ . | clean | sha1sum }}/{{ . | clean }}
         {{- end }}
@@ -115,6 +118,11 @@ spec:
         {{- range default $.Values.hostPathsExporter.watchDirectories $dsDef.watchDirectories }}
         - name: dir-{{ . | clean | sha1sum }}
           mountPath: /mnt/watch/dir-{{ . | clean | sha1sum }}/{{ . | clean }}
+          readOnly: true
+        {{- end }}
+        {{- range default $.Values.hostPathsExporter.watchSpecificExtensionDirectories $dsDef.watchSpecificExtensionDirectories }}
+        - name: dir-{{ .directory| clean | sha1sum }}
+          mountPath: /mnt/watch/dir-{{ .directory | clean | sha1sum }}/{{ .directory | clean | dir }}
           readOnly: true
         {{- end }}
         {{- range default $.Values.hostPathsExporter.watchFiles $dsDef.watchFiles }}
@@ -175,6 +183,14 @@ spec:
       - name: dir-{{ . | clean | sha1sum }}
         hostPath:
           path: {{ . | clean }}
+          {{- if $hostPathType }}
+          type: {{ $hostPathType | quote }}
+          {{- end }}
+      {{- end }}
+      {{- range default $.Values.hostPathsExporter.watchSpecificExtensionDirectories $dsDef.watchSpecificExtensionDirectories }}
+      - name: dir-{{ .directory | clean | sha1sum }}
+        hostPath:
+          path: {{ .directory | clean }}
           {{- if $hostPathType }}
           type: {{ $hostPathType | quote }}
           {{- end }}

--- a/deploy/charts/x509-certificate-exporter/values.yaml
+++ b/deploy/charts/x509-certificate-exporter/values.yaml
@@ -190,6 +190,8 @@ hostPathsExporter:
   hostPathVolumeType: Directory
   # -- [SEE README] List of directory paths of the host to scan for PEM encoded certificate files to be watched and exported as metrics (one level deep)
   watchDirectories: []
+  # -- [SEE README] List of directory paths of the host to scan for specific extension files to be watched and exported as metrics (one level deep)
+  watchSpecificExtensionDirectories: []
   # -- [SEE README] List of file paths of the host for PEM encoded certificates to be watched and exported as metrics (one level deep)
   watchFiles: []
   # -- [SEE README] List of Kubeconf file paths of the host to scan for embedded certificates to export metrics about


### PR DESCRIPTION
As you introduce a recent feature to monitor specific file extension, i've applied it into the helm chart.

You have to use values.yaml like this 

```
---
hostPathsExporter:
  daemonSets:
    nodes:
      watchSpecificExtensionDirectories:
        - directory: /etc/kubernetes/ssl/
          extension: pem
```

After an helm template, it will template it like this 


```
        args:
        - --listen-address=:9793
        - --trim-path-components=3
        - --watch-dir=/mnt/watch/dir-3c7986266497f70a0ca6dc6776cc96e1e1d3dcb6//etc/kubernetes/ssl/*.pem
        - --max-cache-duration=300s
        volumeMounts:
        - name: dir-3c7986266497f70a0ca6dc6776cc96e1e1d3dcb6
          mountPath: /mnt/watch/dir-3c7986266497f70a0ca6dc6776cc96e1e1d3dcb6//etc/kubernetes
          readOnly: true
        ports:
        - name: metrics
          containerPort: 9793
      hostNetwork: false
      volumes:
      - name: dir-3c7986266497f70a0ca6dc6776cc96e1e1d3dcb6
        hostPath:
          path: /etc/kubernetes/ssl
          type: "Directory"
```