### PR TITLE
feat: Add "expires after" to CertificateRenewal alert description

### DIFF
--- a/deploy/charts/x509-certificate-exporter/templates/prometheusrule.yaml
+++ b/deploy/charts/x509-certificate-exporter/templates/prometheusrule.yaml
@@ -61,7 +61,7 @@ spec:
         {{- end }}
       annotations:
         summary: Certificate should be renewed
-        description: Certificate for "{{ "{{" }} $labels.subject_CN {{ "}}" }}" should be renewed {{ "{{if" }} $labels.secret_name {{ "}}" }}in Kubernetes secret "{{ "{{" }} $labels.secret_namespace {{ "}}" }}/{{ "{{" }} $labels.secret_name {{ "}}" }}"{{ "{{else}}" }}at location "{{ "{{" }} $labels.filepath {{ "}}" }}"{{ "{{end}}" }}
+        description: Certificate for "{{ "{{" }} $labels.subject_CN {{ "}}" }}" should be renewed as it expires after {{`{{`}} humanizeDuration $value {{`}}`}} {{ "{{if" }} $labels.secret_name {{ "}}" }}in Kubernetes secret "{{ "{{" }} $labels.secret_namespace {{ "}}" }}/{{ "{{" }} $labels.secret_name {{ "}}" }}"{{ "{{else}}" }}at location "{{ "{{" }} $labels.filepath {{ "}}" }}"{{ "{{end}}" }}
         {{- if .Values.prometheusRules.alertExtraAnnotations }}
         {{- toYaml .Values.prometheusRules.alertExtraAnnotations | nindent 8 }}
         {{- end }}


### PR DESCRIPTION
Currently, the alert description does not include when the certificate will expire:
`Certificate for "example.org" should be renewed in Kubernetes secret "foo/bar-tls"`

After this change:
`Certificate for "example.org" should be renewed as it expires after 5d 22h 39m 55s in Kubernetes secret "foo/bar-tls"`