### PR TITLE
feat: enhance shutdown function to accept context for improved control

### DIFF
--- a/cmd/x509-certificate-exporter/main.go
+++ b/cmd/x509-certificate-exporter/main.go
@@ -1,15 +1,18 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"log/slog"
 	"net/http"
 	_ "net/http/pprof"
 	"os"
+	"os/signal"
 	"path"
 	"runtime"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/KimMachineGun/automemlimit/memlimit"
@@ -192,9 +195,26 @@ func main() {
 		}
 	}
 
-	err = exporter.ListenAndServe()
-	if err != nil {
-		slog.Error("Failed to start server", "reason", err)
+	go func() {
+		err := exporter.ListenAndServe()
+		if err != nil && err != http.ErrServerClosed {
+			slog.Error("Failed to start server", "reason", err)
+			os.Exit(1)
+		}
+	}()
+
+	quit := make(chan os.Signal, 1)
+	signal.Notify(quit, syscall.SIGINT, syscall.SIGTERM)
+	<-quit
+	slog.Info("Shutting down server...")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	if err := exporter.ShutdownWithContext(ctx); err != nil {
+		slog.Error("Failed to gracefully shutdown server", "reason", err)
 		os.Exit(1)
 	}
+
+	slog.Info("Server stopped")
 }

--- a/internal/exporter.go
+++ b/internal/exporter.go
@@ -14,6 +14,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/patrickmn/go-cache"
@@ -27,7 +28,7 @@ import (
 )
 
 var (
-    invalidLabelCharRE = regexp.MustCompile(`[^a-zA-Z0-9_]`)
+	invalidLabelCharRE = regexp.MustCompile(`[^a-zA-Z0-9_]`)
 )
 
 // Exporter : Configuration (from command-line)
@@ -57,6 +58,7 @@ type Exporter struct {
 
 	kubeClient      kubernetes.Interface
 	listener        net.Listener
+	serverMu        sync.RWMutex
 	server          *http.Server
 	isDiscovery     bool
 	secretsCache    *cache.Cache
@@ -128,9 +130,12 @@ func (exporter *Exporter) Serve() error {
 	mux.Handle("/healthz", health.NewHandler())
 	mux.Handle("/metrics", promhttp.Handler())
 
-	exporter.server = &http.Server{
+	exporter.serverMu.Lock()
+	server := &http.Server{
 		Handler: mux,
 	}
+	exporter.server = server
+	exporter.serverMu.Unlock()
 
 	toolkitFlags := web.FlagConfig{
 		WebListenAddresses: &[]string{exporter.ListenAddress},
@@ -138,16 +143,34 @@ func (exporter *Exporter) Serve() error {
 		WebConfigFile:      &exporter.ConfigFile,
 	}
 
-	return web.Serve(exporter.listener, exporter.server, &toolkitFlags, slog.Default())
+	return web.Serve(exporter.listener, server, &toolkitFlags, slog.Default())
 }
 
-// Shutdown : Properly tear down server
+// Shutdown tears down the server using a default background context.
 func (exporter *Exporter) Shutdown() error {
-	if exporter.server != nil {
-		return exporter.server.Shutdown(context.Background())
+	return exporter.ShutdownWithContext(context.Background())
+}
+
+// ShutdownWithContext properly tears down the server using the provided context
+// This allows for setting timeouts and other context-specific configurations
+func (exporter *Exporter) ShutdownWithContext(ctx context.Context) error {
+	exporter.serverMu.RLock()
+	server := exporter.server
+	exporter.serverMu.RUnlock()
+
+	if server == nil {
+		return nil
 	}
 
-	return nil
+	err := server.Shutdown(ctx)
+
+	exporter.serverMu.Lock()
+	if exporter.server == server {
+		exporter.server = nil
+	}
+	exporter.serverMu.Unlock()
+
+	return err
 }
 
 // DiscoverCertificates : Parse all certs in a dry run with verbose logging

--- a/internal/exporter_test.go
+++ b/internal/exporter_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"context"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
@@ -10,16 +11,19 @@ import (
 	"crypto/x509/pkix"
 	"encoding/pem"
 	"fmt"
+	"io"
 	"log"
 	"math/big"
 	"net"
 	"net/http"
+	"net/http/httptest"
 	"os"
 	"path"
 	"path/filepath"
 	"regexp"
 	"runtime"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -970,9 +974,11 @@ func TestDirectoryGlobbing(t *testing.T) {
 }
 
 func TestListenError(t *testing.T) {
-	exporter := &Exporter{ListenAddress: "127.0.0.1:4242"}
+	exporter := &Exporter{ListenAddress: "127.0.0.1:0"}
 	err := exporter.Listen()
 	assert.NoError(t, err)
+
+	exporter.ListenAddress = exporter.listener.Addr().String()
 	err = exporter.Listen()
 	assert.Error(t, err)
 	err = exporter.listener.Close()
@@ -980,13 +986,103 @@ func TestListenError(t *testing.T) {
 }
 
 func TestMultipleShutdown(t *testing.T) {
-	exporter := &Exporter{ListenAddress: "127.0.0.1:4242"}
+	exporter := &Exporter{ListenAddress: "127.0.0.1:0"}
 	err := exporter.Listen()
 	assert.NoError(t, err)
 	err = exporter.Shutdown()
 	assert.NoError(t, err)
 	err = exporter.Shutdown()
 	assert.NoError(t, err)
+}
+
+func TestShutdownWithContext(t *testing.T) {
+	exporter, serveErr := startTestServer(t)
+
+	// Shutdown with normal context
+	ctx := context.Background()
+	err := exporter.ShutdownWithContext(ctx)
+	assert.NoError(t, err)
+	assertServeStopped(t, serveErr)
+
+	// Should be safe to call shutdown again even after server is already shutdown
+	err = exporter.ShutdownWithContext(ctx)
+	assert.NoError(t, err)
+
+	// Verify timeout context is honored while requests are still in flight.
+	releaseRequest := make(chan struct{})
+	var requestStarted atomic.Bool
+	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requestStarted.Store(true)
+		<-releaseRequest
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer testServer.Close()
+
+	exporter = &Exporter{}
+	exporter.serverMu.Lock()
+	exporter.server = testServer.Config
+	exporter.serverMu.Unlock()
+
+	requestErr := make(chan error, 1)
+	go func() {
+		resp, reqErr := http.Get(testServer.URL)
+		if resp != nil {
+			_, _ = io.Copy(io.Discard, resp.Body)
+			_ = resp.Body.Close()
+		}
+		requestErr <- reqErr
+	}()
+
+	require.Eventually(t, requestStarted.Load, time.Second, 10*time.Millisecond)
+
+	timeoutCtx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+	err = exporter.ShutdownWithContext(timeoutCtx)
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
+
+	close(releaseRequest)
+	err = exporter.ShutdownWithContext(context.Background())
+	assert.NoError(t, err)
+
+	select {
+	case reqErr := <-requestErr:
+		assert.NoError(t, reqErr)
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for in-flight request to finish")
+	}
+}
+
+func startTestServer(t *testing.T) (*Exporter, <-chan error) {
+	t.Helper()
+
+	exporter := &Exporter{ListenAddress: "127.0.0.1:0"}
+	require.NoError(t, exporter.Listen())
+
+	serveErr := make(chan error, 1)
+	go func() {
+		serveErr <- exporter.Serve()
+	}()
+
+	require.Eventually(t, func() bool {
+		exporter.serverMu.RLock()
+		defer exporter.serverMu.RUnlock()
+		return exporter.server != nil
+	}, time.Second, 10*time.Millisecond)
+
+	return exporter, serveErr
+}
+
+func assertServeStopped(t *testing.T, serveErr <-chan error) {
+	t.Helper()
+
+	select {
+	case err := <-serveErr:
+		if err != nil {
+			assert.ErrorIs(t, err, http.ErrServerClosed)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for server to stop")
+	}
 }
 
 func testSinglePEM(t *testing.T, expired float64, notBefore time.Time) {


### PR DESCRIPTION
## Overview

This PR completes the old context-shutdown proposal (ref: #172).

Previously, shutdown always used `context.Background()`, so callers could not control timeout/cancellation behavior.

## Changes

- Added `ShutdownWithContext(ctx context.Context)` to `Exporter`.
- Kept `Shutdown()` for backward compatibility by delegating to `ShutdownWithContext(context.Background())`.
- Wired graceful shutdown in `cmd/x509-certificate-exporter/main.go` to use:
- `context.WithTimeout(context.Background(), 10*time.Second)`
- `exporter.ShutdownWithContext(ctx)`
- Guarded `exporter.server` field with `sync.RWMutex` to prevent data races between `Serve()` and `ShutdownWithContext()`.

## Testing

- Added/updated unit tests for context-aware shutdown behavior:
- normal context shutdown
- repeated shutdown calls
- timeout-context shutdown (with in-flight request)

Run:

```sh
go test -v -failfast -timeout 1m ./internal
```

## Related Issue

- #172
