### PR TITLE
fix(helm): add deployment and daemonSet annotations

### DIFF
--- a/deploy/charts/x509-certificate-exporter/README.md
+++ b/deploy/charts/x509-certificate-exporter/README.md
@@ -368,6 +368,7 @@ hostPathsExporter:
 | grafana.annotations | object | `{}` | Annotations added to the Grafana dashboard ConfigMap (example in `values.yaml`) |
 | grafana.extraLabels | object | `{}` | Additional labels added to the Grafana dashboard ConfigMap |
 | secretsExporter.enabled | bool | `true` | Should the TLS Secrets exporter be running |
+| secretsExporter.annotations | object | `{}` | Additional Deployment annotations |
 | secretsExporter.debugMode | bool | `false` | Should debug messages be produced by the TLS Secrets exporter |
 | secretsExporter.replicas | int | `1` | Desired number of TLS Secrets exporter Pod |
 | secretsExporter.restartPolicy | string | `"Always"` | restartPolicy for Pods of the TLS Secrets exporter |
@@ -399,6 +400,7 @@ hostPathsExporter:
 | secretsExporter.kubeApiRateLimits.queriesPerSecond | int | `5` | Maximum rate of queries sent to the API server (per second) |
 | secretsExporter.kubeApiRateLimits.burstQueries | int | `10` | Burst bucket size for queries sent to the API server |
 | secretsExporter.env | list | `[]` | Additional environment variables for container |
+| hostPathsExporter.annotations | object | `{}` | Additional DaemonSet annotations |
 | hostPathsExporter.debugMode | bool | `false` | Should debug messages be produced by hostPath exporters (default for all hostPathsExporter.daemonSets) |
 | hostPathsExporter.restartPolicy | string | `"Always"` | restartPolicy for Pods of hostPath exporters (default for all hostPathsExporter.daemonSets) |
 | hostPathsExporter.updateStrategy | object | `{}` | updateStrategy for DaemonSet of hostPath exporters (default for all hostPathsExporter.daemonSets) |
@@ -435,6 +437,7 @@ hostPathsExporter:
 | prometheusServiceMonitor.scrapeInterval | string | `"60s"` | Target scrape interval set in the ServiceMonitor |
 | prometheusServiceMonitor.scrapeTimeout | string | `"30s"` | Target scrape timeout set in the ServiceMonitor |
 | prometheusServiceMonitor.extraLabels | object | `{}` | Additional labels to add to ServiceMonitor objects |
+| prometheusServiceMonitor.extraAnnotations | object | `{}` | Additional annotations to add to ServiceMonitor objects |
 | prometheusServiceMonitor.metricRelabelings | list | `[]` | Metric relabel config for the ServiceMonitor, see: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#monitoring.coreos.com/v1.Endpoint |
 | prometheusServiceMonitor.relabelings | list | `[]` | Relabel config for the ServiceMonitor, see: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#monitoring.coreos.com/v1.Endpoint |
 | prometheusServiceMonitor.scheme | string | `"http"` | Scheme config for the ServiceMonitor, see: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#monitoring.coreos.com/v1.Endpoint |

--- a/deploy/charts/x509-certificate-exporter/templates/daemonset.yaml
+++ b/deploy/charts/x509-certificate-exporter/templates/daemonset.yaml
@@ -7,6 +7,10 @@
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
+  {{- with default $.Values.hostPathsExporter.annotations $dsDef.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   name: {{ printf "%s-%s" (include "x509-certificate-exporter.fullname" $) $dsName }}
   namespace: {{ include "x509-certificate-exporter.namespace" $ }}
   labels:

--- a/deploy/charts/x509-certificate-exporter/templates/deployment.yaml
+++ b/deploy/charts/x509-certificate-exporter/templates/deployment.yaml
@@ -4,6 +4,10 @@
 apiVersion: {{ include "capabilities.deployment.apiVersion" . }}
 kind: Deployment
 metadata:
+  {{- with .Values.secretsExporter.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   name: {{ include "x509-certificate-exporter.secretsExporterName" . }}
   namespace: {{ include "x509-certificate-exporter.namespace" . }}
   labels:

--- a/deploy/charts/x509-certificate-exporter/values.yaml
+++ b/deploy/charts/x509-certificate-exporter/values.yaml
@@ -61,6 +61,8 @@ grafana:
 secretsExporter:
   # -- Should the TLS Secrets exporter be running
   enabled: true
+  # -- Additional Deployment annotations
+  annotations: {}
   # -- Should debug messages be produced by the TLS Secrets exporter
   debugMode: false
   # -- Desired number of TLS Secrets exporter Pod
@@ -161,6 +163,8 @@ secretsExporter:
   #   value: "1"
 
 hostPathsExporter:
+  # -- Additional DaemonSet annotations
+  annotations: {}
   # -- Should debug messages be produced by hostPath exporters (default for all hostPathsExporter.daemonSets)
   debugMode: false
   # -- restartPolicy for Pods of hostPath exporters (default for all hostPathsExporter.daemonSets)


### PR DESCRIPTION
The following patch adds deployment and daemonSet annotations to values.yaml. These are necessary to apply the workaround described in #460.