### PR TITLE
feat(helm): added extraArgs

### DIFF
--- a/deploy/charts/x509-certificate-exporter/README.md
+++ b/deploy/charts/x509-certificate-exporter/README.md
@@ -385,8 +385,8 @@ hostPathsExporter:
 | secretsExporter.podAnnotations | object | `{}` | Annotations added to Pods of the TLS Secrets exporter |
 | secretsExporter.podSecurityContext | object | check `values.yaml` | PodSecurityContext for Pods of the TLS Secrets exporter |
 | secretsExporter.securityContext | object | check `values.yaml` | SecurityContext for containers of the TLS Secrets exporter |
-| secretsExporter.extraVolumes | list | `[]` | Additionnal volumes added to Pods of the TLS Secrets exporter (combined with global `extraVolumes`) |
-| secretsExporter.extraVolumeMounts | list | `[]` | Additionnal volume mounts added to Pod containers of the TLS Secrets exporter (combined with global `extraVolumeMounts`) |
+| secretsExporter.extraVolumes | list | `[]` | Additional volumes added to Pods of the TLS Secrets exporter (combined with global `extraVolumes`) |
+| secretsExporter.extraVolumeMounts | list | `[]` | Additional volume mounts added to Pod containers of the TLS Secrets exporter (combined with global `extraVolumeMounts`) |
 | secretsExporter.secretTypes | list | check `values.yaml` | Which type of Secrets should be watched ; "key" is the map key in the secret data |
 | secretsExporter.configMapKeys | list | check `values.yaml` | If the exporter should for certificates in configmaps, just specify the keys it needs to watch. E.g.: `configMapKeys: ["tls.crt"]` |
 | secretsExporter.includeNamespaces | list | `[]` | Restrict the list of namespaces the TLS Secrets exporter should scan for certificates to watch (all namespaces if empty) |
@@ -395,6 +395,8 @@ hostPathsExporter:
 | secretsExporter.excludeNamespaceLabels | list | `[]` | Exclude namespaces having these labels. Items can be keys such as `my-label` or also require a value with syntax `my-label=my-value`. |
 | secretsExporter.includeLabels | list | `[]` | Only watch TLS Secrets having these labels (all secrets if empty). Items can be keys such as `my-label` or also require a value with syntax `my-label=my-value`. |
 | secretsExporter.excludeLabels | list | `[]` | Exclude TLS Secrets having these labels. Items can be keys such as `my-label` or also require a value with syntax `my-label=my-value`. |
+| secretsExporter.exposeSecretLabels | list | `[]` | Expose selected labels from kubernetes secrets as prometheus label. |
+| secretsExporter.extraArgs | list | `[]` | Includes extra arguments. Items can be a list of extra arguments that should be added to the command line such as `--watch-file="/extra-cert/tls.crt`. |
 | secretsExporter.cache.enabled | bool | `true` | Enable caching of Kubernetes objects to prevent scraping timeouts |
 | secretsExporter.cache.maxDuration | int | `300` | Maximum time an object can stay in cache unrefreshed (seconds) - it will be at least half of that |
 | secretsExporter.kubeApiRateLimits.enabled | bool | `false` | Should requests to the Kubernetes API server be rate-limited |
@@ -417,8 +419,8 @@ hostPathsExporter:
 | hostPathsExporter.podAnnotations | object | `{}` | Annotations added to Pods of hostPath exporters (default for all hostPathsExporter.daemonSets) |
 | hostPathsExporter.podSecurityContext | object | `{}` | PodSecurityContext for Pods of hostPath exporters (default for all hostPathsExporter.daemonSets) |
 | hostPathsExporter.securityContext | object | check `values.yaml` | SecurityContext for containers of hostPath exporters (default for all hostPathsExporter.daemonSets) |
-| hostPathsExporter.extraVolumes | list | `[]` | Additionnal volumes added to Pods of hostPath exporters (default for all hostPathsExporter.daemonSets ; combined with global `extraVolumes`) |
-| hostPathsExporter.extraVolumeMounts | list | `[]` | Additionnal volume mounts added to Pod containers of hostPath exporters (default for all hostPathsExporter.daemonSets ; combined with global `extraVolumes`) |
+| hostPathsExporter.extraVolumes | list | `[]` | Additional volumes added to Pods of hostPath exporters (default for all hostPathsExporter.daemonSets ; combined with global `extraVolumes`) |
+| hostPathsExporter.extraVolumeMounts | list | `[]` | Additional volume mounts added to Pod containers of hostPath exporters (default for all hostPathsExporter.daemonSets ; combined with global `extraVolumes`) |
 | hostPathsExporter.hostPathVolumeType | string | `"Directory"` | Type for HostPath volumes used with watched paths. Can be set to `""` or null to use Kubernetes defaults. May be required with RKE if Pods don't start. |
 | hostPathsExporter.watchDirectories | list | `[]` | [SEE README] List of directory paths of the host to scan for PEM encoded certificate files to be watched and exported as metrics (one level deep) |
 | hostPathsExporter.watchSpecificExtensionDirectories | list | `[]` | [SEE README] List of directory paths of the host to scan for specific extension files to be watched and exported as metrics (one level deep) |
@@ -471,8 +473,8 @@ hostPathsExporter:
 | podExtraLabels | object | `{}` | Additional labels added to all Pods |
 | podAnnotations | object | `{}` | Annotations added to all Pods |
 | priorityClassName | string | `""` | PriorityClassName set for all Pods by default (could be overrided with `secretsExporter` and `hostPathsExporter` specific values) |
-| extraVolumes | list | `[]` | Additionnal volumes added to all Pods (see also the `secretsExporter` and `hostPathsExporter` variants) |
-| extraVolumeMounts | list | `[]` | Additionnal volume mounts added to all Pod containers (see also the `secretsExporter` and `hostPathsExporter` variants) |
+| extraVolumes | list | `[]` | Additional volumes added to all Pods (see also the `secretsExporter` and `hostPathsExporter` variants) |
+| extraVolumeMounts | list | `[]` | Additional volume mounts added to all Pod containers (see also the `secretsExporter` and `hostPathsExporter` variants) |
 | psp.create | bool | `false` | Should Pod Security Policy objects be created |
 | rbac.create | bool | `true` | Should RBAC objects be created |
 | rbac.secretsExporter.serviceAccountName | string | `nil` | Name of the ServiceAccount for the Secrets exporter (required if `rbac.create=false`) |

--- a/deploy/charts/x509-certificate-exporter/templates/deployment.yaml
+++ b/deploy/charts/x509-certificate-exporter/templates/deployment.yaml
@@ -140,6 +140,9 @@ spec:
         {{- if not (kindIs "invalid" .Values.metricLabelsFilterList) }}
         - --expose-labels={{ .Values.metricLabelsFilterList | join "," }}
         {{- end }}
+        {{- range .Values.secretsExporter.extraArgs }}
+        - {{ . }}
+        {{- end }}
         {{- if .Values.secretsExporter.cache.enabled }}
         - --max-cache-duration={{ .Values.secretsExporter.cache.maxDuration | int }}s
         {{- else }}

--- a/deploy/charts/x509-certificate-exporter/values.yaml
+++ b/deploy/charts/x509-certificate-exporter/values.yaml
@@ -117,9 +117,9 @@ secretsExporter:
     capabilities:
       drop:
       - ALL
-  # -- Additionnal volumes added to Pods of the TLS Secrets exporter (combined with global `extraVolumes`)
+  # -- Additional volumes added to Pods of the TLS Secrets exporter (combined with global `extraVolumes`)
   extraVolumes: []
-  # -- Additionnal volume mounts added to Pod containers of the TLS Secrets exporter (combined with global `extraVolumeMounts`)
+  # -- Additional volume mounts added to Pod containers of the TLS Secrets exporter (combined with global `extraVolumeMounts`)
   extraVolumeMounts: []
 
   # -- Which type of Secrets should be watched ; "key" is the map key in the secret data
@@ -146,6 +146,8 @@ secretsExporter:
   excludeLabels: []
   # -- Expose selected labels from kubernetes secrets as prometheus label.
   exposeSecretLabels: []
+  # -- Includes extra arguments. Items can be a list of extra arguments that should be added to the command line such as `--watch-file="/extra-cert/tls.crt`.
+  extraArgs: []
 
   cache:
     # -- Enable caching of Kubernetes objects to prevent scraping timeouts
@@ -219,9 +221,9 @@ hostPathsExporter:
     capabilities:
       drop:
       - ALL
-  # -- Additionnal volumes added to Pods of hostPath exporters (default for all hostPathsExporter.daemonSets ; combined with global `extraVolumes`)
+  # -- Additional volumes added to Pods of hostPath exporters (default for all hostPathsExporter.daemonSets ; combined with global `extraVolumes`)
   extraVolumes: []
-  # -- Additionnal volume mounts added to Pod containers of hostPath exporters (default for all hostPathsExporter.daemonSets ; combined with global `extraVolumes`)
+  # -- Additional volume mounts added to Pod containers of hostPath exporters (default for all hostPathsExporter.daemonSets ; combined with global `extraVolumes`)
   extraVolumeMounts: []
 
   # -- Type for HostPath volumes used with watched paths. Can be set to `""` or null to use Kubernetes defaults. May be required with RKE if Pods don't start.
@@ -361,10 +363,10 @@ podAnnotations: {}
 # -- PriorityClassName set for all Pods by default (could be overrided with `secretsExporter` and `hostPathsExporter` specific values)
 priorityClassName: ""
 
-# -- Additionnal volumes added to all Pods (see also the `secretsExporter` and `hostPathsExporter` variants)
+# -- Additional volumes added to all Pods (see also the `secretsExporter` and `hostPathsExporter` variants)
 extraVolumes: []
 
-# -- Additionnal volume mounts added to all Pod containers (see also the `secretsExporter` and `hostPathsExporter` variants)
+# -- Additional volume mounts added to all Pod containers (see also the `secretsExporter` and `hostPathsExporter` variants)
 extraVolumeMounts: []
 
 psp:


### PR DESCRIPTION
There is no way to add extra flags or arguments to the secrets exporter deployment. This is helpful when adding custom arguments such as watching a specific certificate.