### PR TITLE
fix(helm): resolve redundant double slashes (//) in certificate monit…

### DIFF
--- a/deploy/charts/x509-certificate-exporter/templates/daemonset.yaml
+++ b/deploy/charts/x509-certificate-exporter/templates/daemonset.yaml
@@ -95,10 +95,10 @@ spec:
         - --watch-dir=/mnt/watch/dir-{{ .directory | clean | sha1sum }}/{{ .directory | clean }}/*.{{ .extension | clean }}
         {{- end }}
         {{- range default $.Values.hostPathsExporter.watchFiles $dsDef.watchFiles }}
-        - --watch-file=/mnt/watch/file-{{ . | clean | sha1sum }}/{{ . | clean }}
+        - --watch-file=/mnt/watch/file-{{ . | clean | sha1sum }}{{ . | clean }}
         {{- end }}
         {{- range default $.Values.hostPathsExporter.watchKubeconfFiles $dsDef.watchKubeconfFiles }}
-        - --watch-kubeconf=/mnt/watch/kube-{{ . | clean | sha1sum }}/{{ . | clean }}
+        - --watch-kubeconf=/mnt/watch/kube-{{ . | clean | sha1sum }}{{ . | clean }}
         {{- end }}
         {{- if not (kindIs "invalid" $.Values.metricLabelsFilterList) }}
         - --expose-labels={{ $.Values.metricLabelsFilterList | join "," }}
@@ -127,12 +127,12 @@ spec:
         {{- end }}
         {{- range default $.Values.hostPathsExporter.watchFiles $dsDef.watchFiles }}
         - name: file-{{ . | clean | sha1sum }}
-          mountPath: /mnt/watch/file-{{ . | clean | sha1sum }}/{{ . | clean | dir }}
+          mountPath: /mnt/watch/file-{{ . | clean | sha1sum }}{{ . | clean | dir }}
           readOnly: true
         {{- end }}
         {{- range default $.Values.hostPathsExporter.watchKubeconfFiles $dsDef.watchKubeconfFiles }}
         - name: kube-{{ . | clean | sha1sum }}
-          mountPath: /mnt/watch/kube-{{ . | clean | sha1sum }}/{{ . | clean | dir }}
+          mountPath: /mnt/watch/kube-{{ . | clean | sha1sum }}{{ . | clean | dir }}
           readOnly: true
         {{- end }}
         {{- if or $.Values.webConfiguration $.Values.webConfigurationExistingSecret }}


### PR DESCRIPTION
In the Helm template generation of certificate monitoring paths, incorrect path concatenation logic resulted in redundant double slashes (//) in --watch-file and --watch-kubeconf parameters, e.g.:
```
...
    - --watch-file=/mnt/watch/file-9dff78b77fe2f4b0f34f77796df3fea5983e5d4b//var/lib/kubelet/pki/kubelet-client-current.pem
    - --watch-file=/mnt/watch/file-15d8ed7db7457d4f5108195ceb52a124a8703898//etc/kubernetes/pki/ca.crt
...
    volumeMounts:
    - mountPath: /mnt/watch/file-9dff78b77fe2f4b0f34f77796df3fea5983e5d4b//var/lib/kubelet/pki
      name: file-9dff78b77fe2f4b0f34f77796df3fea5983e5d4b
      readOnly: true
    - mountPath: /mnt/watch/file-15d8ed7db7457d4f5108195ceb52a124a8703898//etc/kubernetes/pki
      name: file-15d8ed7db7457d4f5108195ceb52a124a8703898
      readOnly: true
    - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
      name: kube-api-access-vmn6h
      readOnly: true
```
This fix adjusts the path cleaning logic in templates to ensure only a single slash is maintained between the hash directory and certificate path.