### PR TITLE
feat: add support for SAN (DNS names and IP addresses).Resolves #458

### DIFF
--- a/internal/collector.go
+++ b/internal/collector.go
@@ -1,9 +1,9 @@
 package internal
 
 import (
+	"log/slog"
 	"runtime"
 	"time"
-	"log/slog"
 
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -33,6 +33,10 @@ var (
 	certValidSinceHelp   = "Indicates the elapsed time since the certificate's not before timestamp"
 	certValidSinceDesc   = prometheus.NewDesc(certValidSinceMetric, certValidSinceHelp, nil, nil)
 
+	certSANMetric = "x509_cert_san"
+	certSANHelp   = "Indicates the Subject Alternative Names (DNS or IP) present in the certificate"
+	certSANDesc   = prometheus.NewDesc(certSANMetric, certSANHelp, nil, nil)
+
 	certErrorMetric = "x509_cert_error"
 	certErrorHelp   = "Indicates wether the corresponding secret has read failure(s)"
 	certErrorDesc   = prometheus.NewDesc(certErrorMetric, certErrorHelp, nil, nil)
@@ -60,7 +64,7 @@ func (collector *collector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- certNotAfterDesc
 	ch <- certErrorsDesc
 	ch <- infoDesc
-
+	ch <- certSANDesc
 	if collector.exporter.ExposeRelativeMetrics {
 		ch <- certExpiresInDesc
 		ch <- certValidSinceDesc
@@ -152,6 +156,26 @@ func (collector *collector) getMetricsForCertificate(certData *parsedCertificate
 			float64(certData.cert.NotAfter.Unix()),
 			labelValues...,
 		),
+	}
+
+	for _, dns := range certData.cert.DNSNames {
+		dnsLabelValues := append(labelValues, dns, "dns")
+		dnsLabelKeys := append(labelKeys, "SAN_value", "SAN_type")
+		metrics = append(metrics, prometheus.MustNewConstMetric(
+			prometheus.NewDesc(certSANMetric, certSANHelp, dnsLabelKeys, nil),
+			prometheus.GaugeValue,
+			1,
+			dnsLabelValues...))
+	}
+
+	for _, ip := range certData.cert.IPAddresses {
+		ipLabelValues := append(labelValues, ip.String(), "address")
+		ipLabelKeys := append(labelKeys, "SAN_value", "SAN_type")
+		metrics = append(metrics, prometheus.MustNewConstMetric(
+			prometheus.NewDesc(certSANMetric, certSANHelp, ipLabelKeys, nil),
+			prometheus.GaugeValue,
+			1,
+			ipLabelValues...))
 	}
 
 	if collector.exporter.ExposeRelativeMetrics {


### PR DESCRIPTION
Introduces a new gauge metric `x509_cert_san` to expose Subject Alternative Names (SANs) from X.509 certificates, with detailed metadata labels for enhanced monitoring and troubleshooting.

Key features:
- Tracks both DNS names and IP addresses via `SAN_type` label ("dns" or "address")
- Includes `SAN_value` label to store the actual DNS/IP entry
- Adds base labels:`filename`,`filepath`,`issuer_CN`,`subject_CN`,`serial_number`, etc.

Example metric output:
```
# HELP x509_cert_san Indicates the Subject Alternative Names (DNS or IP) present in the certificate
# TYPE x509_cert_san gauge
x509_cert_san{SAN_type="address",SAN_value="10.103.97.2",filename="apiserver.crt",filepath="/file/go/src/test/apiserver.crt",issuer_CN="kubernetes",serial_number="8451564427851205067",subject_CN="kube-apiserver"} 1
...
x509_cert_san{SAN_type="address",SAN_value="10.77.0.1",filename="apiserver.crt",filepath="/file/go/src/test/apiserver.crt",issuer_CN="kubernetes",serial_number="8451564427851205067",subject_CN="kube-apiserver"} 1
x509_cert_san{SAN_type="address",SAN_value="127.0.0.1",filename="apiserver.crt",filepath="/file/go/src/test/apiserver.crt",issuer_CN="kubernetes",serial_number="8451564427851205067",subject_CN="kube-apiserver"} 1
...
x509_cert_san{SAN_type="dns",SAN_value="kubernetes.default.svc.cluster.local",filename="apiserver.crt",filepath="/file/go/src/test/apiserver.crt",issuer_CN="kubernetes",serial_number="8451564427851205067",subject_CN="kube-apiserver"} 1
x509_cert_san{SAN_type="dns",SAN_value="localhost",filename="apiserver.crt",filepath="/file/go/src/test/apiserver.crt",issuer_CN="kubernetes",serial_number="8451564427851205067",subject_CN="kube-apiserver"} 1
x509_cert_san{SAN_type="dns",SAN_value="node1",filename="apiserver.crt",filepath="/file/go/src/test/apiserver.crt",issuer_CN="kubernetes",serial_number="8451564427851205067",subject_CN="kube-apiserver"} 1
```
This implementation enables granular filtering of SAN entries (e.g., finding all certificates with a specific DNS name) while preserving full certificate context for cross-referencing with existing metrics.