### PR TITLE
test: adapt metrics decoder to response Content-Type to fix bad testcase

### DIFF
--- a/internal/exporter_test.go
+++ b/internal/exporter_test.go
@@ -1015,7 +1015,7 @@ func testRequest(t *testing.T, exporter *Exporter, cb func(metrics []model.Metri
 		var metric model.MetricFamily
 		metrics := []model.MetricFamily{}
 
-		decoder := expfmt.NewDecoder(res.Body, expfmt.NewFormat(expfmt.TypeProtoText))
+		decoder := expfmt.NewDecoder(res.Body, expfmt.ResponseFormat(res.Header))
 		for {
 			if err := decoder.Decode(&metric); err != nil {
 				break


### PR DESCRIPTION
After bumping prometheus/common to v0.66.1 (in commit 28672a060f012886eb7cc8959fcd68c58197be55), `expfmt.NewDecoder` started to return an error if the caller tried to create a decoder for prototext format, which is not supported (https://github.com/prometheus/common/commit/fc488aa6f985e54490a7e21e5d0db4f5f616438f).

Use `expfmt.ResponseFormat(res.Header)` so the decoder matches whatever format the server actually returns.