### PR TITLE
docs(README): don't generalize memory gains in v4

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ cluster it observes, but equally happy as a standalone binary.
 ## ✨ What's new in v4
 
 - **Full rewrite** around a YAML config file and a pluggable architecture — clean foundations for the project to grow on.
-- **Memory-safe Kubernetes watch** — RAM usage stays flat instead of spiking; expect to set memory limits ~10× lower than before.
+- **Memory-safe Kubernetes watch** — RAM stays flat instead of spiking; on Secret-heavy clusters, memory limits drop ~10×.
 - **Richer PKCS#12 wiring** — full keystore + truststore coverage, flexible passphrase sourcing.
 - **Surface workload metadata** — lift watched resource labels onto emitted certificate series.
 - **Supply-chain hardened** — SLSA Build L3 provenance, cosign-signed binaries, images and chart, SBOM attestations.

--- a/chart/README.md
+++ b/chart/README.md
@@ -47,7 +47,7 @@ cluster it observes, but equally happy as a standalone binary.
 ## ✨ What's new in v4
 
 - **Full rewrite** around a YAML config file and a pluggable architecture — clean foundations for the project to grow on.
-- **Memory-safe Kubernetes watch** — RAM usage stays flat instead of spiking; expect to set memory limits ~10× lower than before.
+- **Memory-safe Kubernetes watch** — RAM stays flat instead of spiking; on Secret-heavy clusters, memory limits drop ~10×.
 - **Richer PKCS#12 wiring** — full keystore + truststore coverage, flexible passphrase sourcing.
 - **Surface workload metadata** — lift watched resource labels onto emitted certificate series.
 - **Supply-chain hardened** — SLSA Build L3 provenance, cosign-signed binaries, images and chart, SBOM attestations.

--- a/chart/README.md.gotmpl
+++ b/chart/README.md.gotmpl
@@ -47,7 +47,7 @@ cluster it observes, but equally happy as a standalone binary.
 ## ✨ What's new in v4
 
 - **Full rewrite** around a YAML config file and a pluggable architecture — clean foundations for the project to grow on.
-- **Memory-safe Kubernetes watch** — RAM usage stays flat instead of spiking; expect to set memory limits ~10× lower than before.
+- **Memory-safe Kubernetes watch** — RAM stays flat instead of spiking; on Secret-heavy clusters, memory limits drop ~10×.
 - **Richer PKCS#12 wiring** — full keystore + truststore coverage, flexible passphrase sourcing.
 - **Surface workload metadata** — lift watched resource labels onto emitted certificate series.
 - **Supply-chain hardened** — SLSA Build L3 provenance, cosign-signed binaries, images and chart, SBOM attestations.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated release notes to clarify memory efficiency of the Kubernetes watch feature. Documentation now explicitly details that RAM usage remains flat and memory limits can drop by up to 10× on Secret-heavy clusters, providing clearer expectations for deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->