### PR TITLE
fix(chart): omit registry segment when image.registry is empty

### DIFF
--- a/chart/README.md
+++ b/chart/README.md
@@ -250,7 +250,7 @@ exporter-toolkit is the recommended path on new installs.
 | extraDeploy | list | `[]` | Additional objects to deploy with the release |
 | extraDeployVerbatim | list | `[]` | Same as `extraDeploy` but objects won't go through the templating engine |
 | imagePullSecrets | list | `[]` | Specify docker-registry secret names as an array |
-| image.registry | string | `"quay.io"` | Exporter image registry |
+| image.registry | string | `"quay.io"` | Exporter image registry. Empty string opts out of the registry prefix and lets the CRI fall back to its configured default (typically docker.io). |
 | image.repository | string | `"enix/x509-certificate-exporter"` | Exporter image repository |
 | image.tag | string | `""` | Exporter image tag (defaults to Chart appVersion) |
 | image.tagSuffix | string | `""` | Appended to the image tag to select a container flavor. Use `-busybox` for a shell-enabled image |
@@ -407,7 +407,7 @@ exporter-toolkit is the recommended path on new installs.
 | rbac.hostPathsExporter.clusterRoleBindingAnnotations | object | `{}` | Annotations added to the ClusterRoleBinding for the hostPath exporters |
 | rbacProxy.enabled | bool | `false` | Should kube-rbac-proxy be used to expose exporters |
 | rbacProxy.tls.existingSecretName | string | `""` | Pre-provisioned Secret carrying `tls.crt` + `tls.key` for the kube-rbac-proxy serving cert. When empty, the chart auto-generates a self-signed cert at install time and reuses it across upgrades via `lookup`. Set this to a cert-manager-managed Secret (or similar) for a cert with a real chain you can rotate independently. |
-| rbacProxy.image.registry | string | `"quay.io"` | kube-rbac-proxy image registry |
+| rbacProxy.image.registry | string | `"quay.io"` | kube-rbac-proxy image registry. Empty string opts out of the registry prefix and lets the CRI fall back to its configured default (typically docker.io). |
 | rbacProxy.image.repository | string | `"brancz/kube-rbac-proxy"` | kube-rbac-proxy image repository |
 | rbacProxy.image.tag | string | `"v0.22.0"` | kube-rbac-proxy image tag |
 | rbacProxy.image.digest | string | `""` | kube-rbac-proxy image digest. When set, takes precedence over `tag` (immutable reference) |

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -85,6 +85,10 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 Return the x509-certificate-exporter image reference.
 Precedence: digest > tag (+ tagSuffix). global.imageRegistry overrides registry.
 When digest is set the tag is omitted from the reference (digest is immutable).
+An empty registry (e.g. `image.registry: ""`) omits the registry segment
+entirely — the kubelet then falls back to its configured default
+(typically docker.io). Without this branch, the resulting ref would
+start with `/` and trigger ImagePullBackOff:InvalidImageName.
 */}}
 {{- define "x509-certificate-exporter.image" -}}
 {{- $registry := .Values.image.registry -}}
@@ -92,17 +96,20 @@ When digest is set the tag is omitted from the reference (digest is immutable).
   {{- $registry = .Values.global.imageRegistry -}}
 {{- end -}}
 {{- $repo := .Values.image.repository -}}
+{{- $prefix := $repo -}}
+{{- if $registry -}}{{- $prefix = printf "%s/%s" $registry $repo -}}{{- end -}}
 {{- if .Values.image.digest -}}
-  {{- printf "%s/%s@%s" $registry $repo .Values.image.digest -}}
+  {{- printf "%s@%s" $prefix .Values.image.digest -}}
 {{- else -}}
   {{- $tag := printf "%s%s" (default .Chart.AppVersion .Values.image.tag | toString) (default "" .Values.image.tagSuffix | toString) -}}
-  {{- printf "%s/%s:%s" $registry $repo $tag -}}
+  {{- printf "%s:%s" $prefix $tag -}}
 {{- end -}}
 {{- end -}}
 
 {{/*
 Return the kube-rbac-proxy image reference.
 Precedence: digest > tag. global.imageRegistry overrides registry.
+Same empty-registry handling as the main image helper.
 */}}
 {{- define "x509-certificate-exporter.rbacProxy.image" -}}
 {{- $registry := .Values.rbacProxy.image.registry -}}
@@ -110,10 +117,12 @@ Precedence: digest > tag. global.imageRegistry overrides registry.
   {{- $registry = .Values.global.imageRegistry -}}
 {{- end -}}
 {{- $repo := .Values.rbacProxy.image.repository -}}
+{{- $prefix := $repo -}}
+{{- if $registry -}}{{- $prefix = printf "%s/%s" $registry $repo -}}{{- end -}}
 {{- if .Values.rbacProxy.image.digest -}}
-  {{- printf "%s/%s@%s" $registry $repo .Values.rbacProxy.image.digest -}}
+  {{- printf "%s@%s" $prefix .Values.rbacProxy.image.digest -}}
 {{- else -}}
-  {{- printf "%s/%s:%s" $registry $repo (.Values.rbacProxy.image.tag | toString) -}}
+  {{- printf "%s:%s" $prefix (.Values.rbacProxy.image.tag | toString) -}}
 {{- end -}}
 {{- end -}}
 

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -276,6 +276,7 @@
         },
         "repository": {
           "default": "enix/x509-certificate-exporter",
+          "minLength": 1,
           "type": "string"
         },
         "tag": {
@@ -289,7 +290,6 @@
       },
       "required": [
         "registry",
-        "repository",
         "tag",
         "tagSuffix",
         "digest"
@@ -728,6 +728,7 @@
             },
             "repository": {
               "default": "brancz/kube-rbac-proxy",
+              "minLength": 1,
               "type": "string"
             },
             "tag": {
@@ -737,7 +738,6 @@
           },
           "required": [
             "registry",
-            "repository",
             "tag",
             "digest"
           ],

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -16,8 +16,12 @@ extraDeployVerbatim: []
 imagePullSecrets: []
 
 image:
-  # -- Exporter image registry
+  # -- Exporter image registry. Empty string opts out of the registry prefix and lets the CRI fall back to its configured default (typically docker.io).
   registry: quay.io
+  # @schema
+  # type: string
+  # minLength: 1
+  # @schema
   # -- Exporter image repository
   repository: enix/x509-certificate-exporter
   # -- Exporter image tag (defaults to Chart appVersion)
@@ -781,8 +785,12 @@ rbacProxy:
     # similar) for a cert with a real chain you can rotate independently.
     existingSecretName: ""
   image:
-    # -- kube-rbac-proxy image registry
+    # -- kube-rbac-proxy image registry. Empty string opts out of the registry prefix and lets the CRI fall back to its configured default (typically docker.io).
     registry: quay.io
+    # @schema
+    # type: string
+    # minLength: 1
+    # @schema
     # -- kube-rbac-proxy image repository
     repository: brancz/kube-rbac-proxy
     # -- kube-rbac-proxy image tag

--- a/test/schema/invalid/image-repository-empty.expect.txt
+++ b/test/schema/invalid/image-repository-empty.expect.txt
@@ -1,0 +1,1 @@
+at '/image/repository'

--- a/test/schema/invalid/image-repository-empty.yaml
+++ b/test/schema/invalid/image-repository-empty.yaml
@@ -1,0 +1,7 @@
+# Empty `image.repository` would render as `<registry>/:<tag>` which
+# kubelet rejects with ImagePullBackOff:InvalidImageName. The schema
+# must reject it (registry-less is fine — see
+# `valid/image-registry-empty.yaml` — but a repo-less ref makes no
+# sense).
+image:
+  repository: ""

--- a/test/schema/valid/image-registry-empty.yaml
+++ b/test/schema/valid/image-registry-empty.yaml
@@ -1,0 +1,10 @@
+# Empty `image.registry` must render a registry-less reference rather
+# than producing `/<repo>:<tag>` (leading slash → InvalidImageName).
+# The kubelet falls back to its configured default registry
+# (typically docker.io) when no registry is set.
+image:
+  registry: ""
+rbacProxy:
+  enabled: true
+  image:
+    registry: ""


### PR DESCRIPTION
Fix #499

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Image references now correctly omit an empty registry value, preventing invalid image names and ImagePullBackOff.

* **Tests**
  * Added validation tests for empty registry cases and rejected empty repository values.

* **Documentation**
  * Clarified configuration docs and schema annotations to document empty-registry behavior and tightened repository validation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/enix/x509-certificate-exporter/pull/593)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->