### PR TITLE
test: improve coverage of k8s/kubeconfig/file sources

### DIFF
--- a/pkg/source/file/file_test.go
+++ b/pkg/source/file/file_test.go
@@ -165,6 +165,25 @@ func TestSkipUnchanged(t *testing.T) {
 	if len(sink2.upsert) != 0 {
 		t.Fatalf("second run with no change should skip: %d", len(sink2.upsert))
 	}
+
+	// Rewrite the file with a fresh certificate; the (mtime, size) cache key
+	// must invalidate and the bundle must be re-emitted. On filesystems that
+	// round mtime to 1 s the back-to-back rewrite can collide with the stamp
+	// captured during sink1 — sleep past the second boundary to guarantee a
+	// distinct mtime there. Size may or may not differ across two random
+	// ECDSA-P256 PEMs, so mtime is the only branch we can rely on here.
+	if !fsHasSubSecondMtime(t, dir) {
+		time.Sleep(1100 * time.Millisecond)
+	}
+	writePEM(t, a, "a2")
+	sink3 := &fakeSink{}
+	src.runOnce(context.Background(), sink3, false)
+	if len(sink3.upsert) != 1 {
+		t.Fatalf("third run after edit should re-parse: %d", len(sink3.upsert))
+	}
+	if cn := sink3.upsert[0].Items[0].Cert.Subject.CommonName; cn != "a2" {
+		t.Fatalf("re-parsed CN = %q, want a2", cn)
+	}
 }
 
 func TestFirstSyncSignal(t *testing.T) {

--- a/pkg/source/k8s/k8s_test.go
+++ b/pkg/source/k8s/k8s_test.go
@@ -49,12 +49,14 @@ func (s *fakeSink) Delete(r cert.SourceRef) {
 	s.delete = append(s.delete, r)
 }
 
-func makeCertPEM(t *testing.T) []byte {
+func makeCertPEM(t *testing.T) []byte { return makeCertPEMCN(t, "leaf") }
+
+func makeCertPEMCN(t *testing.T, cn string) []byte {
 	t.Helper()
 	key, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	tpl := &x509.Certificate{
 		SerialNumber: big.NewInt(1),
-		Subject:      pkix.Name{CommonName: "leaf"},
+		Subject:      pkix.Name{CommonName: cn},
 		NotBefore:    time.Now().Add(-time.Hour),
 		NotAfter:     time.Now().Add(24 * time.Hour),
 	}
@@ -146,6 +148,121 @@ func TestSecretsWatchHandlesDelete(t *testing.T) {
 		defer sink.mu.Unlock()
 		return len(sink.delete) >= 1
 	}, "delete event")
+}
+
+func TestSecretRotationReplacesUpsert(t *testing.T) {
+	// cert-manager rotation pattern: tls.crt is rewritten in place,
+	// same Secret name+namespace. The source must emit a fresh Bundle
+	// (same SourceRef, new cert content) with no Delete in between
+	// — otherwise metrics silently report the OLD cert's expiry
+	// until the next non-trivial Update.
+	pemV1 := makeCertPEMCN(t, "leaf-v1")
+	pemV2 := makeCertPEMCN(t, "leaf-v2")
+	sec := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "tls-prod", Namespace: "ns"},
+		Type:       corev1.SecretTypeTLS,
+		Data:       map[string][]byte{"tls.crt": pemV1},
+	}
+	client := fake.NewSimpleClientset(sec)
+	src := New(Options{
+		Name: "k", Client: client, ResyncEvery: 10 * time.Minute,
+		SecretRules: []SecretTypeRule{{
+			Type: "kubernetes.io/tls", KeyRe: regexp.MustCompile(`^tls\.crt$`), Parser: pem.New(),
+		}},
+	}, nopLogger())
+	sink := &fakeSink{}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() { _ = src.Run(ctx, sink) }()
+
+	waitFor(t, func() bool {
+		sink.mu.Lock()
+		defer sink.mu.Unlock()
+		return len(sink.upsert) >= 1
+	}, "initial upsert with v1")
+
+	sink.mu.Lock()
+	if got := sink.upsert[0].Items[0].Cert.Subject.CommonName; got != "leaf-v1" {
+		t.Fatalf("initial Bundle CN = %q, want leaf-v1", got)
+	}
+	initialRef := sink.upsert[0].Source
+	initialN := len(sink.upsert)
+	sink.mu.Unlock()
+
+	// Rotate in place.
+	sec.Data["tls.crt"] = pemV2
+	if _, err := client.CoreV1().Secrets("ns").Update(ctx, sec, metav1.UpdateOptions{}); err != nil {
+		t.Fatalf("update secret: %v", err)
+	}
+
+	waitFor(t, func() bool {
+		sink.mu.Lock()
+		defer sink.mu.Unlock()
+		if len(sink.upsert) <= initialN {
+			return false
+		}
+		latest := sink.upsert[len(sink.upsert)-1]
+		return len(latest.Items) == 1 && latest.Items[0].Cert.Subject.CommonName == "leaf-v2"
+	}, "rotation upsert with leaf-v2")
+
+	sink.mu.Lock()
+	defer sink.mu.Unlock()
+	if rotatedRef := sink.upsert[len(sink.upsert)-1].Source; rotatedRef.String() != initialRef.String() {
+		t.Fatalf("rotation changed SourceRef: %s → %s", initialRef.String(), rotatedRef.String())
+	}
+	if len(sink.delete) != 0 {
+		t.Fatalf("rotation must replace, not delete + re-add (got %d deletes)", len(sink.delete))
+	}
+}
+
+func TestSecretAndConfigMapSameNameDisambiguated(t *testing.T) {
+	// A Secret and a ConfigMap can legitimately share metadata.name
+	// inside the same namespace (the K8s API keys are independent).
+	// They must surface as two distinct refs in the registry — keyed
+	// by SourceRef.Kind, not by (namespace, name) alone.
+	const shared = "trust-bundle"
+	pemS := makeCertPEMCN(t, "secret-leaf")
+	pemC := makeCertPEMCN(t, "configmap-leaf")
+	sec := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: shared, Namespace: "ns"},
+		Type:       corev1.SecretTypeTLS,
+		Data:       map[string][]byte{"tls.crt": pemS},
+	}
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: shared, Namespace: "ns"},
+		Data:       map[string]string{"ca.crt": string(pemC)},
+	}
+	client := fake.NewSimpleClientset(sec, cm)
+	src := New(Options{
+		Name: "k", Client: client, ResyncEvery: 10 * time.Minute,
+		SecretRules: []SecretTypeRule{{
+			Type: "kubernetes.io/tls", KeyRe: regexp.MustCompile(`^tls\.crt$`), Parser: pem.New(),
+		}},
+		ConfigMapRules: []SecretTypeRule{{KeyRe: regexp.MustCompile(`\.crt$`), Parser: pem.New()}},
+	}, nopLogger())
+	sink := &fakeSink{}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() { _ = src.Run(ctx, sink) }()
+
+	waitFor(t, func() bool {
+		sink.mu.Lock()
+		defer sink.mu.Unlock()
+		return len(sink.upsert) >= 2
+	}, "secret + configmap upserts")
+
+	sink.mu.Lock()
+	defer sink.mu.Unlock()
+	kinds := map[string]string{}
+	for _, b := range sink.upsert {
+		kinds[b.Source.Kind] = b.Items[0].Cert.Subject.CommonName
+	}
+	if cn := kinds["kube-secret"]; cn != "secret-leaf" {
+		t.Errorf("kube-secret CN = %q, want secret-leaf", cn)
+	}
+	if cn := kinds["kube-configmap"]; cn != "configmap-leaf" {
+		t.Errorf("kube-configmap CN = %q, want configmap-leaf", cn)
+	}
 }
 
 func TestConfigMapsWatchEmits(t *testing.T) {

--- a/pkg/source/kubeconfig/kubeconfig_test.go
+++ b/pkg/source/kubeconfig/kubeconfig_test.go
@@ -165,6 +165,57 @@ func TestKubeconfigDeleteOnDisappear(t *testing.T) {
 	}
 }
 
+func TestEmbeddedCertRotationReplacesUpsert(t *testing.T) {
+	// kubelet-rotation pattern: certificate-authority-data is
+	// rewritten in place between two runOnce passes. The source must
+	// emit a fresh Bundle with the SAME SourceRef (path + embedded
+	// kind/key) but the new cert content, and NOT emit a Delete —
+	// the Key (kc/c1/certificate-authority-data) is unchanged.
+	dir := t.TempDir()
+	caV1 := makeCert(t, "ca-v1")
+	caV2 := makeCert(t, "ca-v2")
+	yamlOf := func(b []byte) []byte {
+		return []byte("clusters:\n- name: c1\n  cluster:\n    certificate-authority-data: " +
+			base64.StdEncoding.EncodeToString(b) + "\n")
+	}
+	p := filepath.Join(dir, "kc.yaml")
+	if err := os.WriteFile(p, yamlOf(caV1), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	src := New(Options{Name: "kc", Paths: []string{p}}, nopLogger())
+	sink := &fakeSink{}
+	src.runOnce(context.Background(), sink, true)
+	if len(sink.upsert) != 1 {
+		t.Fatalf("want 1 initial upsert, got %d", len(sink.upsert))
+	}
+	if cn := sink.upsert[0].Items[0].Cert.Subject.CommonName; cn != "ca-v1" {
+		t.Fatalf("initial CN = %q, want ca-v1", cn)
+	}
+	firstRef := sink.upsert[0].Source
+
+	// Rotate the embedded CA in place.
+	if err := os.WriteFile(p, yamlOf(caV2), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	src.runOnce(context.Background(), sink, false)
+
+	if len(sink.upsert) != 2 {
+		t.Fatalf("want 2 upserts after rotation, got %d", len(sink.upsert))
+	}
+	latest := sink.upsert[1]
+	if cn := latest.Items[0].Cert.Subject.CommonName; cn != "ca-v2" {
+		t.Fatalf("rotated CN = %q, want ca-v2", cn)
+	}
+	// Same SourceRef → no Delete should have fired.
+	if latest.Source.String() != firstRef.String() {
+		t.Fatalf("rotation changed SourceRef: %s → %s", firstRef.String(), latest.Source.String())
+	}
+	if len(sink.delete) != 0 {
+		t.Fatalf("rotation must replace, not delete + re-add (got %d deletes)", len(sink.delete))
+	}
+}
+
 func TestNameAndFirstSyncSignal(t *testing.T) {
 	done := make(chan struct{})
 	src := New(Options{Name: "kc", FirstSyncDone: done}, nopLogger())


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added test coverage for certificate rotation scenarios, ensuring updated certificates are properly detected and processed.
  * Added test coverage for cache invalidation when watched certificate files are updated.
  * Added test coverage for disambiguating resources with identical names from different source types.
  * Added test coverage for embedded certificate rotation in kubeconfig data.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/enix/x509-certificate-exporter/pull/595)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->