### PR TITLE
chart: tighten schema annotations on secretsExporter selector arrays

### DIFF
--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -829,45 +829,73 @@
         },
         "excludeConfigMaps": {
           "items": {
-            "required": []
+            "type": "string"
           },
-          "type": "array"
+          "required": [],
+          "type": [
+            "array",
+            "null"
+          ]
         },
         "excludeLabels": {
           "items": {
-            "required": []
+            "type": "string"
           },
-          "type": "array"
+          "required": [],
+          "type": [
+            "array",
+            "null"
+          ]
         },
         "excludeNamespaceLabels": {
           "items": {
-            "required": []
+            "type": "string"
           },
-          "type": "array"
+          "required": [],
+          "type": [
+            "array",
+            "null"
+          ]
         },
         "excludeNamespaces": {
           "items": {
-            "required": []
+            "type": "string"
           },
-          "type": "array"
+          "required": [],
+          "type": [
+            "array",
+            "null"
+          ]
         },
         "excludeSecrets": {
           "items": {
-            "required": []
+            "type": "string"
           },
-          "type": "array"
+          "required": [],
+          "type": [
+            "array",
+            "null"
+          ]
         },
         "exposeConfigMapLabels": {
           "items": {
-            "required": []
+            "type": "string"
           },
-          "type": "array"
+          "required": [],
+          "type": [
+            "array",
+            "null"
+          ]
         },
         "exposeSecretLabels": {
           "items": {
-            "required": []
+            "type": "string"
           },
-          "type": "array"
+          "required": [],
+          "type": [
+            "array",
+            "null"
+          ]
         },
         "extraArgs": {
           "items": {
@@ -889,33 +917,53 @@
         },
         "includeConfigMaps": {
           "items": {
-            "required": []
+            "type": "string"
           },
-          "type": "array"
+          "required": [],
+          "type": [
+            "array",
+            "null"
+          ]
         },
         "includeLabels": {
           "items": {
-            "required": []
+            "type": "string"
           },
-          "type": "array"
+          "required": [],
+          "type": [
+            "array",
+            "null"
+          ]
         },
         "includeNamespaceLabels": {
           "items": {
-            "required": []
+            "type": "string"
           },
-          "type": "array"
+          "required": [],
+          "type": [
+            "array",
+            "null"
+          ]
         },
         "includeNamespaces": {
           "items": {
-            "required": []
+            "type": "string"
           },
-          "type": "array"
+          "required": [],
+          "type": [
+            "array",
+            "null"
+          ]
         },
         "includeSecrets": {
           "items": {
-            "required": []
+            "type": "string"
           },
-          "type": "array"
+          "required": [],
+          "type": [
+            "array",
+            "null"
+          ]
         },
         "kubeApiRateLimits": {
           "additionalProperties": false,
@@ -1102,18 +1150,6 @@
         "extraVolumes",
         "extraVolumeMounts",
         "configMapKeys",
-        "includeNamespaces",
-        "excludeNamespaces",
-        "includeNamespaceLabels",
-        "excludeNamespaceLabels",
-        "includeSecrets",
-        "excludeSecrets",
-        "includeConfigMaps",
-        "excludeConfigMaps",
-        "includeLabels",
-        "excludeLabels",
-        "exposeSecretLabels",
-        "exposeConfigMapLabels",
         "extraArgs",
         "cache",
         "kubeApiRateLimits",

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -301,28 +301,76 @@ secretsExporter:
   # @default -- see `values.yaml`
   configMapKeys: []
 
+  # @schema
+  # type: [array, 'null']
+  # items: {type: string}
+  # @schema
   # -- Restrict the list of namespaces the TLS Secrets exporter should scan for certificates to watch (all namespaces if empty). Each entry is a shell-glob pattern (`*`, `?`, `[abc]`) or a literal name — e.g. `team-*` matches `team-alpha` and `team-beta`.
   includeNamespaces: []
+  # @schema
+  # type: [array, 'null']
+  # items: {type: string}
+  # @schema
   # -- Exclude namespaces from being scanned by the TLS Secrets exporter (evaluated after `includeNamespaces`). Same shell-glob syntax as `includeNamespaces`.
   excludeNamespaces: []
+  # @schema
+  # type: [array, 'null']
+  # items: {type: string}
+  # @schema
   # -- Only watch namespaces having these labels (all namespaces if empty). Items can be keys such as `my-label` or also require a value with syntax `my-label=my-value`.
   includeNamespaceLabels: []
+  # @schema
+  # type: [array, 'null']
+  # items: {type: string}
+  # @schema
   # -- Exclude namespaces having these labels. Items can be keys such as `my-label` or also require a value with syntax `my-label=my-value`.
   excludeNamespaceLabels: []
+  # @schema
+  # type: [array, 'null']
+  # items: {type: string}
+  # @schema
   # -- Only watch Secrets whose name matches one of these entries (all matching Secrets if empty). Each entry is a shell-glob pattern (`*`, `?`, `[abc]`) or a literal name — e.g. `tls-*` matches `tls-prod` and `tls-dev`.
   includeSecrets: []
+  # @schema
+  # type: [array, 'null']
+  # items: {type: string}
+  # @schema
   # -- Exclude Secrets whose name matches one of these entries (evaluated after `includeSecrets`). Same shell-glob syntax as `includeSecrets`.
   excludeSecrets: []
+  # @schema
+  # type: [array, 'null']
+  # items: {type: string}
+  # @schema
   # -- Only watch ConfigMaps whose name matches one of these entries (all matching ConfigMaps if empty). Same shell-glob syntax as `includeSecrets`.
   includeConfigMaps: []
+  # @schema
+  # type: [array, 'null']
+  # items: {type: string}
+  # @schema
   # -- Exclude ConfigMaps whose name matches one of these entries (evaluated after `includeConfigMaps`). Same shell-glob syntax as `includeSecrets`.
   excludeConfigMaps: []
+  # @schema
+  # type: [array, 'null']
+  # items: {type: string}
+  # @schema
   # -- Only watch TLS Secrets having these labels (all secrets if empty). Items can be keys such as `my-label` or also require a value with syntax `my-label=my-value`.
   includeLabels: []
+  # @schema
+  # type: [array, 'null']
+  # items: {type: string}
+  # @schema
   # -- Exclude TLS Secrets having these labels. Items can be keys such as `my-label` or also require a value with syntax `my-label=my-value`.
   excludeLabels: []
+  # @schema
+  # type: [array, 'null']
+  # items: {type: string}
+  # @schema
   # -- Expose selected labels from Kubernetes Secrets as Prometheus labels. **Beware of high-cardinality labels** (e.g. `pod-template-hash`, `controller-revision-hash`, build/git SHAs, timestamps, request IDs): each unique value adds a fresh series for every certificate metric, which can quickly explode the Prometheus index. Stick to slow-changing identifiers (app, team, environment, owner).
   exposeSecretLabels: []
+  # @schema
+  # type: [array, 'null']
+  # items: {type: string}
+  # @schema
   # -- Expose selected labels from Kubernetes ConfigMaps as Prometheus labels. Same caveat as `exposeSecretLabels` — keep the list to slow-changing identifiers and avoid high-cardinality values.
   exposeConfigMapLabels: []
   # -- Additional arguments to append to the exporter command line. E.g.: `--watch-file="/extra-cert/tls.crt"`.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated secrets exporter filter configuration to accept nullable values, making previously required filter fields now optional.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/enix/x509-certificate-exporter/pull/596)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->