### PR TITLE
feat: add support for JKS and JCEKS keystores and truststores

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ cluster it observes, but equally happy as a standalone binary.
 - **Memory-safe Kubernetes watch** — RAM stays flat instead of spiking; on Secret-heavy clusters, memory limits drop ~10×.
 - **Richer PKCS#12 wiring** — full keystore + truststore coverage, flexible passphrase sourcing.
 - **DER consumption** — raw cert / CRL blobs as served by HTTP CRL Distribution Points are now first-class inputs.
+- **JKS / JCEKS support** — Java KeyStore and JCEKS stores.
 - **CRL freshness monitoring** — Certificate Revocation Lists are tracked alongside certs, with alerts before they go stale.
 - **Surface workload metadata** — lift watched resource labels onto emitted certificate series.
 - **Supply-chain hardened** — SLSA Build L3 provenance, cosign-signed binaries, images and chart, SBOM attestations.
@@ -55,6 +56,9 @@ cluster it observes, but equally happy as a standalone binary.
 - **PKCS#12** keystores and truststores, with passphrase pulled from a
   sibling key in the same Secret, an external file, a cross-namespace
   Secret reference, or none (`tryEmptyPassphrase`).
+- **JKS / JCEKS** keystores and truststores — magic-byte auto-detection
+  between JKS and JCEKS; passphrase from a sibling key, external file,
+  or `tryEmptyPassphrase`.
 - **Certificate Revocation Lists** — `X509 CRL` PEM blocks (intermixed
   freely with `CERTIFICATE` blocks) and raw DER `*.crl` files
   (`format: der`) are parsed into the dedicated `x509_crl_*` family so

--- a/chart/README.md
+++ b/chart/README.md
@@ -50,6 +50,7 @@ cluster it observes, but equally happy as a standalone binary.
 - **Memory-safe Kubernetes watch** — RAM stays flat instead of spiking; on Secret-heavy clusters, memory limits drop ~10×.
 - **Richer PKCS#12 wiring** — full keystore + truststore coverage, flexible passphrase sourcing.
 - **DER consumption** — raw cert / CRL blobs as served by HTTP CRL Distribution Points are now first-class inputs.
+- **JKS / JCEKS support** — Java KeyStore and JCEKS stores.
 - **CRL freshness monitoring** — Certificate Revocation Lists are tracked alongside certs, with alerts before they go stale.
 - **Surface workload metadata** — lift watched resource labels onto emitted certificate series.
 - **Supply-chain hardened** — SLSA Build L3 provenance, cosign-signed binaries, images and chart, SBOM attestations.
@@ -64,6 +65,9 @@ cluster it observes, but equally happy as a standalone binary.
 - **PKCS#12** keystores and truststores, with passphrase pulled from a
   sibling key in the same Secret, an external file, a cross-namespace
   Secret reference, or none (`tryEmptyPassphrase`).
+- **JKS / JCEKS** keystores and truststores — magic-byte auto-detection
+  between JKS and JCEKS; passphrase from a sibling key, external file,
+  or `tryEmptyPassphrase`.
 - **Certificate Revocation Lists** — `X509 CRL` PEM blocks (intermixed
   freely with `CERTIFICATE` blocks) and raw DER `*.crl` files
   (`format: der`) are parsed into the dedicated `x509_crl_*` family so
@@ -165,15 +169,14 @@ The default install runs a single Deployment watching
 `kubernetes.io/tls` Secrets across all namespaces — disable with
 `secretsExporter.enabled: false`.
 
-### Multiple Secret types, PKCS#12, and JKS
+### Multiple Secret types and PKCS#12
 
 `secretsExporter.secretTypes` accepts any mix of types and keys: a
 literal `key` (regex `^<key>$` is built for you) or a `keyPatterns`
 list for full regex control, with optional `format: pkcs12` plus a
-`pkcs12:` block, or `format: jks` plus a `jks:` block. Passphrases
-are pulled from a sibling Secret key (`pkcs12.passphraseKey` /
-`jks.passphraseKey`), an external file, a cross-namespace Secret ref
-(pkcs12 only), or skipped entirely with `tryEmptyPassphrase: true` for
+`pkcs12:` block. Passphrases are pulled from a sibling Secret key
+(`pkcs12.passphraseKey`), an external file, a cross-namespace Secret
+ref, or skipped entirely with `tryEmptyPassphrase: true` for
 passwordless keystores.
 
 ### Watching ConfigMaps

--- a/chart/README.md
+++ b/chart/README.md
@@ -165,14 +165,15 @@ The default install runs a single Deployment watching
 `kubernetes.io/tls` Secrets across all namespaces — disable with
 `secretsExporter.enabled: false`.
 
-### Multiple Secret types and PKCS#12
+### Multiple Secret types, PKCS#12, and JKS
 
 `secretsExporter.secretTypes` accepts any mix of types and keys: a
 literal `key` (regex `^<key>$` is built for you) or a `keyPatterns`
 list for full regex control, with optional `format: pkcs12` plus a
-`pkcs12:` block. Passphrases are pulled from a sibling Secret key
-(`pkcs12.passphraseKey`), an external file, a cross-namespace Secret
-ref, or skipped entirely with `tryEmptyPassphrase: true` for
+`pkcs12:` block, or `format: jks` plus a `jks:` block. Passphrases
+are pulled from a sibling Secret key (`pkcs12.passphraseKey` /
+`jks.passphraseKey`), an external file, a cross-namespace Secret ref
+(pkcs12 only), or skipped entirely with `tryEmptyPassphrase: true` for
 passwordless keystores.
 
 ### Watching ConfigMaps
@@ -309,7 +310,7 @@ exporter-toolkit is the recommended path on new installs.
 | secretsExporter.securityContext | object | see `values.yaml` | SecurityContext for containers of the TLS Secrets exporter |
 | secretsExporter.extraVolumes | list | `[]` | Additional volumes added to Pods of the TLS Secrets exporter (combined with global `extraVolumes`) |
 | secretsExporter.extraVolumeMounts | list | `[]` | Additional volume mounts added to Pod containers of the TLS Secrets exporter (combined with global `extraVolumeMounts`) |
-| secretsExporter.secretTypes | list | see `values.yaml` | Which type of Secrets should be watched. Each entry takes either `key` (a single Secret data key — the matching regex `^<key>$` is built for you) or `keyPatterns` (a list of regexes, full control). Optional `format` is `pem` (default), `pkcs12`, or `der` (single raw cert or CRL blob, the format produced by CRL Distribution Points); `pkcs12` block accepts `passphrase`, `passphraseKey` (read passphrase from a sibling key in the same Secret), `passphraseFile`, `passphraseSecretRef`, `tryEmptyPassphrase`. |
+| secretsExporter.secretTypes | list | see `values.yaml` | Which type of Secrets should be watched. Each entry takes either `key` (a single Secret data key — the matching regex `^<key>$` is built for you) or `keyPatterns` (a list of regexes, full control). Optional `format` is `pem` (default), `pkcs12`, `der`, or `jks` (Java KeyStore); `pkcs12` block accepts `passphrase`, `passphraseKey` (read passphrase from a sibling key in the same Secret), `passphraseFile`, `passphraseSecretRef`, `tryEmptyPassphrase`; `jks` block accepts the same fields except `passphraseSecretRef`. |
 | secretsExporter.configMapKeys | list | see `values.yaml` | If the exporter should watch for certificates in ConfigMaps, just specify the keys it needs to watch. E.g.: `configMapKeys: ["tls.crt"]` |
 | secretsExporter.includeNamespaces | list | `[]` | Restrict the list of namespaces the TLS Secrets exporter should scan for certificates to watch (all namespaces if empty). Each entry is a shell-glob pattern (`*`, `?`, `[abc]`) or a literal name — e.g. `team-*` matches `team-alpha` and `team-beta`. |
 | secretsExporter.excludeNamespaces | list | `[]` | Exclude namespaces from being scanned by the TLS Secrets exporter (evaluated after `includeNamespaces`). Same shell-glob syntax as `includeNamespaces`. |

--- a/chart/README.md.gotmpl
+++ b/chart/README.md.gotmpl
@@ -50,6 +50,7 @@ cluster it observes, but equally happy as a standalone binary.
 - **Memory-safe Kubernetes watch** — RAM stays flat instead of spiking; on Secret-heavy clusters, memory limits drop ~10×.
 - **Richer PKCS#12 wiring** — full keystore + truststore coverage, flexible passphrase sourcing.
 - **DER consumption** — raw cert / CRL blobs as served by HTTP CRL Distribution Points are now first-class inputs.
+- **JKS / JCEKS support** — Java KeyStore and JCEKS stores.
 - **CRL freshness monitoring** — Certificate Revocation Lists are tracked alongside certs, with alerts before they go stale.
 - **Surface workload metadata** — lift watched resource labels onto emitted certificate series.
 - **Supply-chain hardened** — SLSA Build L3 provenance, cosign-signed binaries, images and chart, SBOM attestations.
@@ -64,6 +65,9 @@ cluster it observes, but equally happy as a standalone binary.
 - **PKCS#12** keystores and truststores, with passphrase pulled from a
   sibling key in the same Secret, an external file, a cross-namespace
   Secret reference, or none (`tryEmptyPassphrase`).
+- **JKS / JCEKS** keystores and truststores — magic-byte auto-detection
+  between JKS and JCEKS; passphrase from a sibling key, external file,
+  or `tryEmptyPassphrase`.
 - **Certificate Revocation Lists** — `X509 CRL` PEM blocks (intermixed
   freely with `CERTIFICATE` blocks) and raw DER `*.crl` files
   (`format: der`) are parsed into the dedicated `x509_crl_*` family so

--- a/chart/templates/configmap.yaml
+++ b/chart/templates/configmap.yaml
@@ -71,6 +71,10 @@ data:
               pkcs12:
                 {{- toYaml . | nindent 16 }}
               {{- end }}
+              {{- with .jks }}
+              jks:
+                {{- toYaml . | nindent 16 }}
+              {{- end }}
             {{- end }}
           exposeLabels: {{ if .Values.secretsExporter.exposeSecretLabels }}{{ .Values.secretsExporter.exposeSecretLabels | toJson }}{{ else }}[]{{ end }}
         {{- if .Values.secretsExporter.configMapKeys }}

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -1188,6 +1188,25 @@
                 ],
                 "required": []
               },
+              "jks": {
+                "additionalProperties": false,
+                "properties": {
+                  "passphrase": {
+                    "type": "string"
+                  },
+                  "passphraseFile": {
+                    "type": "string"
+                  },
+                  "passphraseKey": {
+                    "type": "string"
+                  },
+                  "tryEmptyPassphrase": {
+                    "type": "boolean"
+                  }
+                },
+                "required": [],
+                "type": "object"
+              },
               "key": {
                 "type": "string"
               },
@@ -1227,25 +1246,6 @@
                       "key"
                     ],
                     "type": "object"
-                  },
-                  "tryEmptyPassphrase": {
-                    "type": "boolean"
-                  }
-                },
-                "required": [],
-                "type": "object"
-              },
-              "jks": {
-                "additionalProperties": false,
-                "properties": {
-                  "passphrase": {
-                    "type": "string"
-                  },
-                  "passphraseFile": {
-                    "type": "string"
-                  },
-                  "passphraseKey": {
-                    "type": "string"
                   },
                   "tryEmptyPassphrase": {
                     "type": "boolean"

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -1183,7 +1183,8 @@
                 "enum": [
                   "pem",
                   "pkcs12",
-                  "der"
+                  "der",
+                  "jks"
                 ],
                 "required": []
               },
@@ -1226,6 +1227,25 @@
                       "key"
                     ],
                     "type": "object"
+                  },
+                  "tryEmptyPassphrase": {
+                    "type": "boolean"
+                  }
+                },
+                "required": [],
+                "type": "object"
+              },
+              "jks": {
+                "additionalProperties": false,
+                "properties": {
+                  "passphrase": {
+                    "type": "string"
+                  },
+                  "passphraseFile": {
+                    "type": "string"
+                  },
+                  "passphraseKey": {
+                    "type": "string"
                   },
                   "tryEmptyPassphrase": {
                     "type": "boolean"

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -265,7 +265,7 @@ secretsExporter:
   #     keyPatterns:
   #       type: array
   #       items: {type: string}
-  #     format: {enum: [pem, pkcs12, der]}
+  #     format: {enum: [pem, pkcs12, der, jks]}
   #     pkcs12:
   #       type: object
   #       additionalProperties: false
@@ -282,6 +282,14 @@ secretsExporter:
   #             name: {type: string}
   #             key: {type: string}
   #         tryEmptyPassphrase: {type: boolean}
+  #     jks:
+  #       type: object
+  #       additionalProperties: false
+  #       properties:
+  #         passphrase: {type: string}
+  #         passphraseKey: {type: string}
+  #         passphraseFile: {type: string}
+  #         tryEmptyPassphrase: {type: boolean}
   #   oneOf:
   #     - required: [key]
   #     - required: [keyPatterns]
@@ -289,11 +297,11 @@ secretsExporter:
   # -- Which type of Secrets should be watched. Each entry takes either `key`
   # (a single Secret data key — the matching regex `^<key>$` is built for
   # you) or `keyPatterns` (a list of regexes, full control). Optional
-  # `format` is `pem` (default), `pkcs12`, or `der` (single raw cert or
-  # CRL blob, the format produced by CRL Distribution Points); `pkcs12`
-  # block accepts `passphrase`, `passphraseKey` (read passphrase from a
-  # sibling key in the same Secret), `passphraseFile`,
-  # `passphraseSecretRef`, `tryEmptyPassphrase`.
+  # `format` is `pem` (default), `pkcs12`, `der`, or `jks` (Java KeyStore);
+  # `pkcs12` block accepts `passphrase`, `passphraseKey` (read passphrase from
+  # a sibling key in the same Secret), `passphraseFile`, `passphraseSecretRef`,
+  # `tryEmptyPassphrase`; `jks` block accepts the same fields except
+  # `passphraseSecretRef`.
   # @default -- see `values.yaml`
   secretTypes:
     - type: kubernetes.io/tls

--- a/cmd/x509-certificate-exporter/main.go
+++ b/cmd/x509-certificate-exporter/main.go
@@ -31,6 +31,7 @@ import (
 	"github.com/enix/x509-certificate-exporter/v4/internal/server"
 	"github.com/enix/x509-certificate-exporter/v4/pkg/cert"
 	derparser "github.com/enix/x509-certificate-exporter/v4/pkg/cert/der"
+	jksparser "github.com/enix/x509-certificate-exporter/v4/pkg/cert/jks"
 	pemparser "github.com/enix/x509-certificate-exporter/v4/pkg/cert/pem"
 	pkcs12parser "github.com/enix/x509-certificate-exporter/v4/pkg/cert/pkcs12"
 	"github.com/enix/x509-certificate-exporter/v4/pkg/fileglob"
@@ -145,6 +146,7 @@ func run() error {
 		ExposeExpired:          cfg.Metrics.ExposeExpired,
 		ExposeDiagnostics:      cfg.Metrics.ExposeDiagnostics,
 		Pkcs12InUse:            pkcs12InUse(cfg),
+		JksInUse:               jksInUse(cfg),
 		SubjectFields:          cfg.Metrics.ExposeSubjectFields,
 		IssuerFields:           cfg.Metrics.ExposeIssuerFields,
 		TrimPathComponents:     cfg.Metrics.TrimPathComponents,
@@ -319,6 +321,30 @@ func pkcs12InUse(cfg config.Config) bool {
 	return false
 }
 
+// jksInUse reports whether any source declares a `jks` format.
+// The result drives whether the registry registers the
+// `x509_jks_passphrase_failures_total` counter.
+func jksInUse(cfg config.Config) bool {
+	for _, s := range cfg.Sources {
+		for _, f := range s.Formats {
+			if f == cert.FormatJKS {
+				return true
+			}
+		}
+		if s.Secrets != nil {
+			for _, t := range s.Secrets.Types {
+				if t.Format == cert.FormatJKS {
+					return true
+				}
+			}
+		}
+		if s.ConfigMaps != nil && s.ConfigMaps.Format == cert.FormatJKS {
+			return true
+		}
+	}
+	return false
+}
+
 func exposedLabelsFromConfig(cfg config.Config) (secrets, configmaps, cabundles []string) {
 	seen := map[string]struct{}{}
 	for _, s := range cfg.Sources {
@@ -406,6 +432,23 @@ func buildFileSource(s config.Source, cfg config.Config, ready func(bool), logge
 			parseOpts.Pkcs12TryEmpty = true
 		}
 	}
+	if s.Jks != nil {
+		if s.Jks.Passphrase != "" {
+			parseOpts.JksPassphrase = s.Jks.Passphrase
+		}
+		if s.Jks.PassphraseFile != "" {
+			data, err := os.ReadFile(s.Jks.PassphraseFile)
+			if err != nil {
+				return nil, fmt.Errorf("read jks passphraseFile: %w", err)
+			}
+			parseOpts.JksPassphrase = trimNewline(string(data))
+		}
+		if s.Jks.TryEmptyPassphrase != nil {
+			parseOpts.JksTryEmpty = *s.Jks.TryEmptyPassphrase
+		} else {
+			parseOpts.JksTryEmpty = true
+		}
+	}
 	for _, f := range s.Formats {
 		switch f {
 		case cert.FormatPEM:
@@ -414,6 +457,8 @@ func buildFileSource(s config.Source, cfg config.Config, ready func(bool), logge
 			parsers = append(parsers, pkcs12parser.New())
 		case cert.FormatDER:
 			parsers = append(parsers, derparser.New())
+		case cert.FormatJKS:
+			parsers = append(parsers, jksparser.New())
 		}
 	}
 	follow := true
@@ -472,6 +517,8 @@ func buildKubeSource(ctx context.Context, s config.Source, ready func(bool), reg
 				parser = pkcs12parser.New()
 			case cert.FormatDER:
 				parser = derparser.New()
+			case cert.FormatJKS:
+				parser = jksparser.New()
 			default:
 				return nil, fmt.Errorf("secret type %q: unsupported format %q", t.Type, format)
 			}
@@ -493,6 +540,16 @@ func buildKubeSource(ctx context.Context, s config.Source, ready func(bool), reg
 						rule.ParseOpts.Pkcs12TryEmpty = true
 					}
 				}
+				if t.Jks != nil {
+					if t.Jks.PassphraseKey != "" {
+						rule.JksPassphraseKey = t.Jks.PassphraseKey
+					}
+					if t.Jks.TryEmptyPassphrase != nil {
+						rule.ParseOpts.JksTryEmpty = *t.Jks.TryEmptyPassphrase
+					} else {
+						rule.ParseOpts.JksTryEmpty = true
+					}
+				}
 				rules = append(rules, rule)
 			}
 		}
@@ -511,6 +568,8 @@ func buildKubeSource(ctx context.Context, s config.Source, ready func(bool), reg
 			parser = pkcs12parser.New()
 		case cert.FormatDER:
 			parser = derparser.New()
+		case cert.FormatJKS:
+			parser = jksparser.New()
 		default:
 			return nil, fmt.Errorf("configMaps format %q unsupported", format)
 		}

--- a/dev/scenarios/jks.go
+++ b/dev/scenarios/jks.go
@@ -1,0 +1,29 @@
+package scenarios
+
+import (
+	"bytes"
+	"crypto/x509"
+	"time"
+
+	"github.com/pavlo-v-chernykh/keystore-go/v4"
+)
+
+// EncodeJKSTrustStore builds a JKS truststore holding the given CA certs.
+func EncodeJKSTrustStore(cas []*x509.Certificate, passphrase string) ([]byte, error) {
+	ks := keystore.New()
+	for i, c := range cas {
+		alias := string(rune('a' + i))
+		err := ks.SetTrustedCertificateEntry(alias, keystore.TrustedCertificateEntry{
+			CreationTime: time.Now(),
+			Certificate:  keystore.Certificate{Type: "X.509", Content: c.Raw},
+		})
+		if err != nil {
+			return nil, err
+		}
+	}
+	var buf bytes.Buffer
+	if err := ks.Store(&buf, []byte(passphrase)); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}

--- a/dev/scenarios/scenarios.go
+++ b/dev/scenarios/scenarios.go
@@ -25,6 +25,10 @@ const (
 	// secretTypes.pkcs12.passphraseKey points to that key.
 	PKCS12Passphrase    = "letmein"
 	PKCS12PassphraseKey = "keystore-passphrase"
+
+	// JKS passphrase constants — parallel to PKCS#12.
+	JKSPassphrase    = "changeit"
+	JKSPassphraseKey = "jks-passphrase"
 )
 
 // Lifecycle classifies the temporal state of an expected cert.
@@ -44,6 +48,7 @@ const (
 	ErrNone           ParseError = ""
 	ErrBadPEM         ParseError = "bad_pem"
 	ErrBadPKCS12      ParseError = "bad_pkcs12"
+	ErrBadJKS         ParseError = "bad_jks"
 	ErrBadPassphrase  ParseError = "bad_passphrase"
 	ErrNoCertificates ParseError = "no_certificate_found"
 )
@@ -379,6 +384,67 @@ func build() {
 		},
 		Watched: true,
 		Expect:  []ExpectCert{{Key: "keystore.p12", ParseError: ErrBadPassphrase}},
+	})
+
+	// ─── Opaque — JKS truststore (two CA certs, passphrase from passphraseKey) ─
+	jksCa1, _, err := Selfsigned(CertSpec{
+		CN: "JKS Trust Anchor One", O: []string{"x509ce-dev"},
+		NotBefore: in(-time.Hour), NotAfter: in(720 * day),
+		Algo: AlgoECDSAP256, IsCA: true,
+	})
+	must(err)
+	jksCa2, _, err := Selfsigned(CertSpec{
+		CN: "JKS Trust Anchor Two", O: []string{"x509ce-dev"},
+		NotBefore: in(-time.Hour), NotAfter: in(720 * day),
+		Algo: AlgoRSA2048, IsCA: true,
+	})
+	must(err)
+	jksTruststore, err := EncodeJKSTrustStore([]*x509.Certificate{jksCa1, jksCa2}, JKSPassphrase)
+	must(err)
+	sc = append(sc, Scenario{
+		Namespace: "x509ce-jks", Name: "truststore",
+		Kind: "Secret", SecretType: "Opaque",
+		Data: map[string][]byte{
+			"truststore.jks": jksTruststore,
+			JKSPassphraseKey: []byte(JKSPassphrase),
+		},
+		Watched: true,
+		Expect: []ExpectCert{
+			{Key: "truststore.jks", SubjectCN: "JKS Trust Anchor One", Lifecycle: LifecycleValid},
+			{Key: "truststore.jks", SubjectCN: "JKS Trust Anchor Two", Lifecycle: LifecycleValid},
+		},
+	})
+
+	// ─── Opaque — JKS wrong passphrase ──────────────────────────────────
+	jksWrongPwCa, _, err := Selfsigned(CertSpec{
+		CN: "JKS Wrong PW CA", O: []string{"x509ce-dev"},
+		NotBefore: in(-time.Hour), NotAfter: in(180 * day),
+		Algo: AlgoECDSAP256, IsCA: true,
+	})
+	must(err)
+	jksWrongPwStore, err := EncodeJKSTrustStore([]*x509.Certificate{jksWrongPwCa}, JKSPassphrase)
+	must(err)
+	sc = append(sc, Scenario{
+		Namespace: "x509ce-errors", Name: "wrong-passphrase-jks",
+		Kind: "Secret", SecretType: "Opaque",
+		Data: map[string][]byte{
+			"truststore.jks": jksWrongPwStore,
+			JKSPassphraseKey: []byte("not-the-right-password"),
+		},
+		Watched: true,
+		Expect:  []ExpectCert{{Key: "truststore.jks", ParseError: ErrBadPassphrase}},
+	})
+
+	// ─── Opaque — corrupt JKS bytes ─────────────────────────────────────
+	sc = append(sc, Scenario{
+		Namespace: "x509ce-errors", Name: "bad-jks",
+		Kind: "Secret", SecretType: "Opaque",
+		Data: map[string][]byte{
+			"truststore.jks": []byte("garbage-not-jks"),
+			JKSPassphraseKey: []byte(JKSPassphrase),
+		},
+		Watched: true,
+		Expect:  []ExpectCert{{Key: "truststore.jks", ParseError: ErrBadJKS}},
 	})
 
 	// ─── Negative — namespace excluded by label ─────────────────────────

--- a/dev/scenarios/scenarios_test.go
+++ b/dev/scenarios/scenarios_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/enix/x509-certificate-exporter/v4/pkg/cert"
 	"github.com/enix/x509-certificate-exporter/v4/pkg/cert/der"
+	"github.com/enix/x509-certificate-exporter/v4/pkg/cert/jks"
 	"github.com/enix/x509-certificate-exporter/v4/pkg/cert/pem"
 	"github.com/enix/x509-certificate-exporter/v4/pkg/cert/pkcs12"
 )
@@ -19,6 +20,7 @@ func TestAllParseWithExporter(t *testing.T) {
 	pemP := pem.New()
 	p12P := pkcs12.New()
 	derP := der.New()
+	jksP := jks.New()
 
 	for _, sc := range All() {
 		sc := sc
@@ -42,6 +44,12 @@ func TestAllParseWithExporter(t *testing.T) {
 					}
 					tryEmpty := key == "keystore-empty.p12"
 					b = p12P.Parse(blob, ref, cert.ParseOptions{Pkcs12Passphrase: pp, Pkcs12TryEmpty: tryEmpty})
+				case isJKSKey(key):
+					pp := JKSPassphrase
+					if other, ok := sc.Data[JKSPassphraseKey]; ok {
+						pp = string(other)
+					}
+					b = jksP.Parse(blob, ref, cert.ParseOptions{JksPassphrase: pp})
 				case isDERKey(key):
 					b = derP.Parse(blob, ref, cert.ParseOptions{})
 				default:
@@ -55,6 +63,11 @@ func TestAllParseWithExporter(t *testing.T) {
 
 func isPKCS12Key(k string) bool {
 	return k == "keystore.p12" || k == "keystore-empty.p12" || k == "truststore.p12"
+}
+
+// isJKSKey reflects the dev/values.yaml secretTypes routing.
+func isJKSKey(k string) bool {
+	return strings.HasSuffix(k, ".jks")
 }
 
 // isDERKey reflects the dev/values.yaml secretTypes routing: any key

--- a/dev/values.yaml
+++ b/dev/values.yaml
@@ -5,6 +5,7 @@
 #   - Opaque PEM with custom data keys
 #   - Opaque PKCS#12 (encrypted via passphraseKey + passwordless via
 #     tryEmptyPassphrase)
+#   - Opaque JKS truststore (passphrase from passphraseKey)
 #   - ConfigMaps holding tls.crt
 #   - Per-cert error metrics, relative-time metrics
 #   - exposeSecretLabels for the rich-DN scenario
@@ -51,6 +52,12 @@ secretsExporter:
     - type: Opaque
       key: revocation.crl
       format: der
+    # JKS truststore — passphrase pulled from a sibling key in the same Secret
+    - type: Opaque
+      key: truststore.jks
+      format: jks
+      jks:
+        passphraseKey: jks-passphrase
 
   # Watch ConfigMaps holding a tls.crt key.
   configMapKeys:

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -37,6 +37,7 @@ The exporter splits its output into four families:
 | Per-source | `x509_source_errors_total` | counter | always |
 | Per-source | `x509_kube_watch_resyncs_total` | counter | Kubernetes sources only |
 | Per-source | `x509_pkcs12_passphrase_failures_total` | counter | auto: when any source declares `format: pkcs12` |
+| Per-source | `x509_jks_passphrase_failures_total` | counter | auto: when any source declares `format: jks` |
 | Per-source | `x509_cert_collision_total` | counter | always |
 | Diagnostic | `x509_parse_duration_seconds` | histogram | `metrics.exposeDiagnostics: true` |
 | Diagnostic | `x509_kube_request_duration_seconds` | histogram | `metrics.exposeDiagnostics: true`, Kubernetes sources only |
@@ -410,6 +411,21 @@ was wrong.
 A spike usually means a Secret was rotated but the sibling passphrase
 key wasn't, or a `passphraseFile` was stale.
 
+### `x509_jks_passphrase_failures_total`
+
+JKS / JCEKS keystore decoding attempts that failed because the passphrase
+was wrong.
+
+- **Type**: counter
+- **Labels**: `source_name`
+- **Auto-gated**: registered only when at least one source declares
+  `format: jks` (file source `formats:`, kubernetes source
+  `secrets.types[].format`, or `configMaps.format`). Deployments
+  without JKS don't see the metric in `/metrics` at all.
+
+A spike usually means a Secret was rotated but the sibling passphrase
+key wasn't, or a `passphraseFile` was stale.
+
 ### `x509_cert_collision_total`
 
 Number of times the registry detected two distinct certificates that
@@ -512,9 +528,9 @@ etc.) into the internal certificate representation.
 - **Buckets**: `0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1, 5` seconds
 - **Emitted only when `metrics.exposeDiagnostics` is `true`.**
 
-`format` takes one of `pem` or `pkcs12`. PKCS#12 is meaningfully slower
-because of the KDF — expect millisecond-range parse times on PEM and
-double-digit-millisecond on PKCS#12.
+`format` takes one of `pem`, `pkcs12`, `der`, or `jks`. PKCS#12 and JKS are
+meaningfully slower because of their KDF — expect millisecond-range parse
+times on PEM/DER and double-digit-millisecond on PKCS#12/JKS.
 
 ### `x509_kube_request_duration_seconds`
 
@@ -604,7 +620,8 @@ metrics provider with the synthetic `source_kind="kubernetes"`,
 | `bad_pem` | any source running the PEM parser (file, kubeconfig, kube-secret with `format: pem`, kube-configmap) | PEM block present but malformed |
 | `no_certificate_found` | same | The bundle decoded successfully but contained no `CERTIFICATE` block |
 | `bad_pkcs12` | any source running the PKCS#12 parser (file with `formats: [pkcs12]`, kube-secret / kube-configmap with `format: pkcs12`) | PKCS#12 archive malformed or uses an unsupported algorithm |
-| `bad_passphrase` | same | PKCS#12 archive structurally valid but the configured passphrase was wrong |
+| `bad_jks` | any source running the JKS parser (file with `formats: [jks]`, kube-secret / kube-configmap with `format: jks`) | JKS / JCEKS archive malformed or magic bytes not recognised |
+| `bad_passphrase` | PKCS#12 or JKS parser | Archive structurally valid but the configured passphrase was wrong |
 | `read_failed` | `file`, `kubeconfig` | Generic I/O error opening or reading a file |
 | `permission_denied` | `file` | EACCES on a watched path |
 | `not_found` | `file` | Path disappeared between announcement and read |

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.26.2
 require (
 	github.com/KimMachineGun/automemlimit v0.7.5
 	github.com/alecthomas/kong v1.15.0
+	github.com/pavlo-v-chernykh/keystore-go/v4 v4.5.0
 	github.com/prometheus/client_golang v1.23.2
 	github.com/prometheus/client_model v0.6.2
 	github.com/prometheus/common v0.67.5

--- a/go.sum
+++ b/go.sum
@@ -94,6 +94,8 @@ github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f h1:KUppIJq7/+SVif2QVs3tOP0zanoHgBEVAwHxUSIzRqU=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
+github.com/pavlo-v-chernykh/keystore-go/v4 v4.5.0 h1:2nosf3P75OZv2/ZO/9Px5ZgZ5gbKrzA3joN1QMfOGMQ=
+github.com/pavlo-v-chernykh/keystore-go/v4 v4.5.0/go.mod h1:lAVhWwbNaveeJmxrxuSTxMgKpF6DjnuVpn6T8WiBwYQ=
 github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58 h1:onHthvaw9LFnH4t2DcNVpwGmV9E1BkGknEliJkfwQj0=
 github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58/go.mod h1:DXv8WO4yhMYhSNPKjeNKa5WY9YCIEBRbNzFFPJbWO6Y=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -109,6 +109,7 @@ type Source struct {
 	RefreshInterval   time.Duration `yaml:"refreshInterval,omitempty"`
 	Formats           []string      `yaml:"formats,omitempty"`
 	Pkcs12            *Pkcs12       `yaml:"pkcs12,omitempty"`
+	Jks               *Jks          `yaml:"jks,omitempty"`
 
 	// PathMappings declares foreign↔local path-prefix translations applied
 	// when resolving symlinks (and the scope within which their targets must
@@ -149,6 +150,13 @@ type Pkcs12 struct {
 	TryEmptyPassphrase   *bool      `yaml:"tryEmptyPassphrase,omitempty"`
 }
 
+type Jks struct {
+	Passphrase         string `yaml:"passphrase,omitempty"`
+	PassphraseFile     string `yaml:"passphraseFile,omitempty"`
+	PassphraseKey      string `yaml:"passphraseKey,omitempty"`
+	TryEmptyPassphrase *bool  `yaml:"tryEmptyPassphrase,omitempty"`
+}
+
 type SecretRef struct {
 	Namespace string `yaml:"namespace"`
 	Name      string `yaml:"name"`
@@ -181,6 +189,7 @@ type SecretTypeCfg struct {
 	KeyPatterns []string `yaml:"keyPatterns"`
 	Format      string   `yaml:"format"`
 	Pkcs12      *Pkcs12  `yaml:"pkcs12,omitempty"`
+	Jks         *Jks     `yaml:"jks,omitempty"`
 }
 
 type ConfigMapsCfg struct {
@@ -381,9 +390,9 @@ func validateSource(i int, s Source) error {
 		}
 		for _, f := range s.Formats {
 			switch f {
-			case cert.FormatPEM, cert.FormatPKCS12, cert.FormatDER:
+			case cert.FormatPEM, cert.FormatPKCS12, cert.FormatDER, cert.FormatJKS:
 			default:
-				return fmt.Errorf("%s.formats: unsupported format %q (must be pem|pkcs12|der)", prefix, f)
+				return fmt.Errorf("%s.formats: unsupported format %q (must be pem|pkcs12|der|jks)", prefix, f)
 			}
 		}
 	case KindKubeconfig:

--- a/pkg/cert/cert.go
+++ b/pkg/cert/cert.go
@@ -45,6 +45,13 @@ const (
 	// The wire format has no self-framing so concatenated DER is not
 	// supported — one DER object per source bytes.
 	FormatDER = "der"
+	// FormatJKS consumes a Java KeyStore (JKS) or Java Cryptography
+	// Extension KeyStore (JCEKS). Both variants are auto-detected via
+	// their leading magic bytes (`0xFEEDFEED` for JKS, `0xCECECECE` for
+	// JCEKS). Truststore and keystore entries are both surfaced; only
+	// the cert chain attached to each entry is read — private keys are
+	// never decrypted.
+	FormatJKS = "jks"
 )
 
 // SourceRef identifies where a Bundle was found. It is the unit of identity
@@ -138,6 +145,11 @@ type ParseOptions struct {
 	Pkcs12Passphrase string
 	// Pkcs12TryEmpty, if true and Pkcs12Passphrase fails, retries with "".
 	Pkcs12TryEmpty bool
+	// JksPassphrase is the passphrase to use for JKS / JCEKS decoding.
+	// Empty string is a valid passphrase for unprotected keystores.
+	JksPassphrase string
+	// JksTryEmpty, if true and JksPassphrase fails, retries with "".
+	JksTryEmpty bool
 }
 
 // Sink receives Bundles from Sources and forwards them to the registry.

--- a/pkg/cert/jks/jks.go
+++ b/pkg/cert/jks/jks.go
@@ -1,0 +1,193 @@
+// Package jks implements the JKS / JCEKS FormatParser.
+//
+// JKS (Java KeyStore, magic `0xFEEDFEED`) and JCEKS (Java Cryptography
+// Extension KeyStore, magic `0xCECECECE`) are the two pre-PKCS#12 Java
+// keystore formats still in widespread use in legacy Spring Boot
+// configurations, Apache Tomcat / ActiveMQ / Kafka deployments, and
+// many vendor appliances. Both store either:
+//
+//   - TrustedCertificateEntries (truststore mode) — every entry is a
+//     standalone CA / trust anchor we surface as an Item;
+//   - PrivateKeyEntries (keystore mode) — each entry pairs an encrypted
+//     private key with a cert chain. We only read the chain.
+//
+// Behaviour:
+//
+//   - leading magic bytes determine the variant; mismatching bytes
+//     surface as `bad_jks`;
+//   - the passphrase is applied store-level for integrity check (and
+//     for JCEKS entry decryption when needed). A wrong passphrase
+//     surfaces as `bad_passphrase`;
+//   - JksTryEmpty retries with "" exactly like the PKCS#12 parser;
+//   - an otherwise valid keystore with zero certs (truly empty) surfaces
+//     as `no_certificate_found`.
+//
+// Passphrases are never logged. Private keys are never decoded.
+package jks
+
+import (
+	"bytes"
+	"crypto/x509"
+	"encoding/binary"
+	"fmt"
+	"strings"
+
+	"github.com/pavlo-v-chernykh/keystore-go/v4"
+
+	"github.com/enix/x509-certificate-exporter/v4/pkg/cert"
+)
+
+// Magic numbers as written by sun.security.provider.JavaKeyStore /
+// com.sun.crypto.provider.JceKeyStore. The first 4 bytes of the wire
+// format. Anything else is rejected with `bad_jks` before keystore-go
+// gets a chance to emit its own less-specific error.
+const (
+	magicJKS   uint32 = 0xFEEDFEED
+	magicJCEKS uint32 = 0xCECECECE
+)
+
+// Parser is stateless and safe for concurrent use.
+type Parser struct{}
+
+// New returns a Parser. Provided for symmetry with other parsers.
+func New() Parser { return Parser{} }
+
+// Format implements cert.FormatParser.
+func (Parser) Format() string { return cert.FormatJKS }
+
+// Parse implements cert.FormatParser. The passphrase is taken from
+// opts.JksPassphrase; if it fails and opts.JksTryEmpty is true, a
+// second attempt is made with "".
+func (Parser) Parse(data []byte, ref cert.SourceRef, opts cert.ParseOptions) cert.Bundle {
+	b := cert.Bundle{Source: ref}
+
+	if !looksLikeJKS(data) {
+		b.Errors = append(b.Errors, cert.ItemError{
+			Index:  -1,
+			Reason: cert.ReasonBadJKS,
+			Err:    fmt.Errorf("magic bytes do not match JKS (0xFEEDFEED) or JCEKS (0xCECECECE)"),
+		})
+		return b
+	}
+
+	pass := opts.JksPassphrase
+	items, err := decode(data, pass)
+	if err != nil && opts.JksTryEmpty && pass != "" {
+		if items2, err2 := decode(data, ""); err2 == nil {
+			items = items2
+			err = nil
+		}
+	}
+	if err != nil {
+		reason := cert.ReasonBadJKS
+		if isPasswordErr(err) {
+			reason = cert.ReasonBadPassphrase
+		}
+		b.Errors = append(b.Errors, cert.ItemError{
+			Index: -1, Reason: reason, Err: err,
+		})
+		return b
+	}
+	if len(items) == 0 {
+		b.Errors = append(b.Errors, cert.ItemError{
+			Index: -1, Reason: cert.ReasonNoCertificateFound,
+		})
+		return b
+	}
+	for i, it := range items {
+		b.Items = append(b.Items, cert.Item{
+			Index: i,
+			Cert:  it.cert,
+			Role:  it.role,
+		})
+	}
+	return b
+}
+
+// looksLikeJKS rejects anything that is not at least 4 bytes starting
+// with one of the known magic numbers. This pre-filter is cheap and
+// produces a sharper error message than letting keystore-go fail
+// somewhere inside its TLV scanner.
+func looksLikeJKS(data []byte) bool {
+	if len(data) < 4 {
+		return false
+	}
+	m := binary.BigEndian.Uint32(data[:4])
+	return m == magicJKS || m == magicJCEKS
+}
+
+type itemWithRole struct {
+	cert *x509.Certificate
+	role cert.Role
+}
+
+func decode(data []byte, pass string) ([]itemWithRole, error) {
+	ks := keystore.New()
+	if err := ks.Load(bytes.NewReader(data), []byte(pass)); err != nil {
+		return nil, err
+	}
+	var out []itemWithRole
+	for _, alias := range ks.Aliases() {
+		switch {
+		case ks.IsTrustedCertificateEntry(alias):
+			e, err := ks.GetTrustedCertificateEntry(alias)
+			if err != nil {
+				return nil, fmt.Errorf("truststore entry %q: %w", alias, err)
+			}
+			c, err := x509.ParseCertificate(e.Certificate.Content)
+			if err != nil {
+				return nil, fmt.Errorf("truststore entry %q parse: %w", alias, err)
+			}
+			out = append(out, itemWithRole{cert: c, role: classifyTrustStore(c)})
+		case ks.IsPrivateKeyEntry(alias):
+			// Read the chain only — never touch the private key.
+			// GetPrivateKeyEntryCertificateChain reads ONLY the cert
+			// chain attached to a PrivateKeyEntry, with no key
+			// decryption attempt — the right primitive for an
+			// expiry-monitoring exporter that has no business
+			// decoding production private keys.
+			chain, err := ks.GetPrivateKeyEntryCertificateChain(alias)
+			if err != nil {
+				return nil, fmt.Errorf("keystore entry %q chain: %w", alias, err)
+			}
+			for i, cc := range chain {
+				c, err := x509.ParseCertificate(cc.Content)
+				if err != nil {
+					return nil, fmt.Errorf("keystore entry %q chain[%d]: %w", alias, i, err)
+				}
+				role := cert.RoleLeaf
+				if i > 0 {
+					role = classifyChain(c)
+				}
+				out = append(out, itemWithRole{cert: c, role: role})
+			}
+		}
+	}
+	return out, nil
+}
+
+// isPasswordErr distinguishes a wrong-passphrase outcome from other
+// failure modes. keystore-go does not export a sentinel for the
+// HMAC-based store-integrity check, so we match on the substring
+// "invalid digest" surfaced by Load(). Since the magic-byte pre-filter
+// above already rules out non-JKS / non-JCEKS inputs, a digest
+// mismatch at this stage overwhelmingly indicates a wrong password
+// (the alternative is store corruption, which is rare in practice and
+// surfaces with the same operator action: investigate the file).
+func isPasswordErr(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "invalid digest")
+}
+
+func classifyTrustStore(c *x509.Certificate) cert.Role {
+	if c.IsCA {
+		return cert.RoleCA
+	}
+	return cert.RoleUnknown
+}
+
+func classifyChain(c *x509.Certificate) cert.Role {
+	if c.IsCA {
+		return cert.RoleIntermediate
+	}
+	return cert.RoleUnknown
+}

--- a/pkg/cert/jks/jks_fuzz_test.go
+++ b/pkg/cert/jks/jks_fuzz_test.go
@@ -1,0 +1,76 @@
+package jks
+
+import (
+	"bytes"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/binary"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/pavlo-v-chernykh/keystore-go/v4"
+
+	"github.com/enix/x509-certificate-exporter/v4/pkg/cert"
+)
+
+func makeCertForFuzz() (*x509.Certificate, []byte, *ecdsa.PrivateKey) {
+	key, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	tpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "fuzz-seed"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(48 * time.Hour),
+		BasicConstraintsValid: true, IsCA: true,
+	}
+	der, _ := x509.CreateCertificate(rand.Reader, tpl, tpl, &key.PublicKey, key)
+	c, _ := x509.ParseCertificate(der)
+	return c, der, key
+}
+
+// FuzzParse exercises the JKS parser on arbitrary bytes. Contract:
+// Parse must never panic, regardless of input. Truncated headers,
+// magic-byte collisions, oversize lengths, near-valid keystores —
+// all must surface as Bundle.Errors entries, never as a runtime
+// crash.
+func FuzzParse(f *testing.F) {
+	// Seed with a real JKS truststore so the fuzzer has a valid
+	// starting point to mutate towards interesting edge cases.
+	ca, _, _ := makeCertForFuzz()
+	ks := keystore.New()
+	_ = ks.SetTrustedCertificateEntry("trust", keystore.TrustedCertificateEntry{
+		CreationTime: time.Now(),
+		Certificate:  keystore.Certificate{Type: "X.509", Content: ca.Raw},
+	})
+	var buf bytes.Buffer
+	_ = ks.Store(&buf, []byte("seed-pw"))
+	validJKS := buf.Bytes()
+
+	magicJKSBytes := make([]byte, 4)
+	binary.BigEndian.PutUint32(magicJKSBytes, magicJKS)
+	magicJCEKSBytes := make([]byte, 4)
+	binary.BigEndian.PutUint32(magicJCEKSBytes, magicJCEKS)
+
+	for _, seed := range [][]byte{
+		nil,
+		{},
+		{0x00, 0x00, 0x00},                 // too short for magic
+		magicJKSBytes,                       // magic only, no body
+		magicJCEKSBytes,                     // JCEKS magic only
+		append(magicJKSBytes, 0xff, 0xff),  // magic + 2 garbage bytes
+		validJKS,                            // valid JKS
+		validJKS[:len(validJKS)/2],          // truncated
+		[]byte("-----BEGIN CERTIFICATE-----\n"), // misrouted PEM
+	} {
+		f.Add(seed)
+	}
+
+	p := New()
+	ref := cert.SourceRef{Kind: "fuzz", SourceName: "fuzz"}
+	f.Fuzz(func(_ *testing.T, data []byte) {
+		_ = p.Parse(data, ref, cert.ParseOptions{JksPassphrase: "seed-pw"})
+	})
+}

--- a/pkg/cert/jks/jks_test.go
+++ b/pkg/cert/jks/jks_test.go
@@ -1,0 +1,215 @@
+package jks
+
+import (
+	"bytes"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/pavlo-v-chernykh/keystore-go/v4"
+
+	"github.com/enix/x509-certificate-exporter/v4/pkg/cert"
+)
+
+func makeCert(t *testing.T, cn string, isCA bool) (*x509.Certificate, []byte, *ecdsa.PrivateKey) {
+	t.Helper()
+	key, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	tpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(time.Now().UnixNano()),
+		Subject:               pkix.Name{CommonName: cn},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		BasicConstraintsValid: true,
+		IsCA:                  isCA,
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tpl, tpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	x, _ := x509.ParseCertificate(der)
+	return x, der, key
+}
+
+// buildTrustStoreJKS writes a JKS truststore holding the given certs
+// under predictable aliases. password is store-level.
+func buildTrustStoreJKS(t *testing.T, password string, certs ...*x509.Certificate) []byte {
+	t.Helper()
+	ks := keystore.New()
+	for i, c := range certs {
+		alias := "trust-" + string(rune('a'+i))
+		err := ks.SetTrustedCertificateEntry(alias, keystore.TrustedCertificateEntry{
+			CreationTime: time.Now(),
+			Certificate: keystore.Certificate{
+				Type:    "X.509",
+				Content: c.Raw,
+			},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	var buf bytes.Buffer
+	if err := ks.Store(&buf, []byte(password)); err != nil {
+		t.Fatal(err)
+	}
+	return buf.Bytes()
+}
+
+// buildKeyStoreJKS writes a JKS keystore containing one
+// PrivateKeyEntry whose cert chain is [leaf, intermediate].
+func buildKeyStoreJKS(t *testing.T, password string, leaf, inter *x509.Certificate, leafKey *ecdsa.PrivateKey) []byte {
+	t.Helper()
+	keyDER, err := x509.MarshalPKCS8PrivateKey(leafKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ks := keystore.New()
+	chain := []keystore.Certificate{
+		{Type: "X.509", Content: leaf.Raw},
+		{Type: "X.509", Content: inter.Raw},
+	}
+	err = ks.SetPrivateKeyEntry("leaf", keystore.PrivateKeyEntry{
+		CreationTime:     time.Now(),
+		PrivateKey:       keyDER,
+		CertificateChain: chain,
+	}, []byte(password))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var buf bytes.Buffer
+	if err := ks.Store(&buf, []byte(password)); err != nil {
+		t.Fatal(err)
+	}
+	return buf.Bytes()
+}
+
+func TestParseTrustStore(t *testing.T) {
+	ca, _, _ := makeCert(t, "Trusted Root", true)
+	other, _, _ := makeCert(t, "Trusted Other", true)
+	data := buildTrustStoreJKS(t, "changeit", ca, other)
+	b := New().Parse(data, cert.SourceRef{Kind: "file"}, cert.ParseOptions{JksPassphrase: "changeit"})
+	if len(b.Errors) != 0 {
+		t.Fatalf("unexpected errors: %v", b.Errors)
+	}
+	if len(b.Items) != 2 {
+		t.Fatalf("want 2 items, got %d", len(b.Items))
+	}
+	for _, it := range b.Items {
+		if it.Role != cert.RoleCA {
+			t.Errorf("truststore CA entry should have RoleCA, got %s", it.Role)
+		}
+	}
+}
+
+func TestParseKeyStoreChain(t *testing.T) {
+	leaf, _, leafKey := makeCert(t, "leaf.example.test", false)
+	inter, _, _ := makeCert(t, "intermediate", true)
+	data := buildKeyStoreJKS(t, "secret", leaf, inter, leafKey)
+	b := New().Parse(data, cert.SourceRef{Kind: "file"}, cert.ParseOptions{JksPassphrase: "secret"})
+	if len(b.Errors) != 0 {
+		t.Fatalf("unexpected errors: %v", b.Errors)
+	}
+	if len(b.Items) != 2 {
+		t.Fatalf("want 2 chain items, got %d", len(b.Items))
+	}
+	if b.Items[0].Role != cert.RoleLeaf {
+		t.Fatalf("first item should be leaf, got %s", b.Items[0].Role)
+	}
+	if b.Items[1].Role != cert.RoleIntermediate {
+		t.Fatalf("second item should be intermediate, got %s", b.Items[1].Role)
+	}
+	if b.Items[0].Cert.Subject.CommonName != "leaf.example.test" {
+		t.Fatalf("leaf CN = %q", b.Items[0].Cert.Subject.CommonName)
+	}
+}
+
+func TestParseWrongPassphraseReportsBadPassphrase(t *testing.T) {
+	ca, _, _ := makeCert(t, "ca", true)
+	data := buildTrustStoreJKS(t, "right-pass", ca)
+	b := New().Parse(data, cert.SourceRef{Kind: "file"}, cert.ParseOptions{JksPassphrase: "wrong-pass"})
+	if !b.HasFatalError() {
+		t.Fatalf("wrong passphrase must produce a fatal error")
+	}
+	if got := b.Errors[0].Reason; got != cert.ReasonBadPassphrase {
+		t.Fatalf("reason = %q, want bad_passphrase", got)
+	}
+}
+
+func TestTryEmptyPassphraseFallback(t *testing.T) {
+	ca, _, _ := makeCert(t, "ca", true)
+	// Build a keystore protected by an empty password.
+	data := buildTrustStoreJKS(t, "", ca)
+	// Caller supplies a wrong non-empty password but enables fallback.
+	b := New().Parse(data, cert.SourceRef{Kind: "file"}, cert.ParseOptions{
+		JksPassphrase: "definitely-wrong",
+		JksTryEmpty:   true,
+	})
+	if len(b.Errors) != 0 {
+		t.Fatalf("expected empty-passphrase fallback to succeed: %v", b.Errors)
+	}
+	if len(b.Items) != 1 {
+		t.Fatalf("want 1 item, got %d", len(b.Items))
+	}
+}
+
+func TestParseGarbageRejectsBeforeKeystoreGo(t *testing.T) {
+	b := New().Parse([]byte{0x00, 0x01, 0x02, 0x03}, cert.SourceRef{Kind: "file"}, cert.ParseOptions{})
+	if !b.HasFatalError() {
+		t.Fatalf("garbage should yield a fatal error")
+	}
+	if got := b.Errors[0].Reason; got != cert.ReasonBadJKS {
+		t.Fatalf("reason = %q, want bad_jks", got)
+	}
+}
+
+func TestParseEmptyReportsBadJKS(t *testing.T) {
+	b := New().Parse(nil, cert.SourceRef{Kind: "file"}, cert.ParseOptions{})
+	if !b.HasFatalError() {
+		t.Fatalf("empty input should yield a fatal error")
+	}
+	if got := b.Errors[0].Reason; got != cert.ReasonBadJKS {
+		t.Fatalf("reason = %q, want bad_jks", got)
+	}
+}
+
+func TestParseMisroutedPEMReportsBadJKS(t *testing.T) {
+	// A PEM blob fed to the JKS parser should be rejected by the
+	// magic-byte pre-filter, never reach keystore-go.
+	data := []byte("-----BEGIN CERTIFICATE-----\nMIIB\n-----END CERTIFICATE-----\n")
+	b := New().Parse(data, cert.SourceRef{Kind: "file"}, cert.ParseOptions{})
+	if !b.HasFatalError() {
+		t.Fatalf("PEM input should be rejected")
+	}
+	if got := b.Errors[0].Reason; got != cert.ReasonBadJKS {
+		t.Fatalf("reason = %q, want bad_jks", got)
+	}
+}
+
+func TestFormat(t *testing.T) {
+	if New().Format() != "jks" {
+		t.Fatalf("Format = %q, want jks", New().Format())
+	}
+}
+
+func TestEmptyKeystoreReportsNoCertFound(t *testing.T) {
+	// A valid JKS with zero entries — Load() succeeds, Aliases()
+	// returns empty.
+	ks := keystore.New()
+	var buf bytes.Buffer
+	if err := ks.Store(&buf, []byte("changeit")); err != nil {
+		t.Fatal(err)
+	}
+	b := New().Parse(buf.Bytes(), cert.SourceRef{Kind: "file"}, cert.ParseOptions{JksPassphrase: "changeit"})
+	if !b.HasFatalError() {
+		t.Fatalf("empty keystore should yield no_certificate_found")
+	}
+	if got := b.Errors[0].Reason; got != cert.ReasonNoCertificateFound {
+		t.Fatalf("reason = %q, want no_certificate_found", got)
+	}
+}

--- a/pkg/cert/reason.go
+++ b/pkg/cert/reason.go
@@ -6,6 +6,7 @@ const (
 	ReasonBadPEM             = "bad_pem"
 	ReasonBadCRL             = "bad_crl"
 	ReasonBadDER             = "bad_der"
+	ReasonBadJKS             = "bad_jks"
 	ReasonNoCertificateFound = "no_certificate_found"
 	ReasonBadPKCS12          = "bad_pkcs12"
 	ReasonBadPassphrase      = "bad_passphrase"

--- a/pkg/registry/collector.go
+++ b/pkg/registry/collector.go
@@ -120,6 +120,9 @@ func (r *Registry) Describe(ch chan<- *prometheus.Desc) {
 	if r.pkcs12PassphraseFailures != nil {
 		r.pkcs12PassphraseFailures.Describe(ch)
 	}
+	if r.jksPassphraseFailures != nil {
+		r.jksPassphraseFailures.Describe(ch)
+	}
 	ch <- r.buildInfo.Desc()
 	r.descs.describe(ch)
 }
@@ -156,6 +159,9 @@ func (r *Registry) Collect(ch chan<- prometheus.Metric) {
 	}
 	if r.pkcs12PassphraseFailures != nil {
 		r.pkcs12PassphraseFailures.Collect(ch)
+	}
+	if r.jksPassphraseFailures != nil {
+		r.jksPassphraseFailures.Collect(ch)
 	}
 	ch <- r.buildInfo
 

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -49,6 +49,9 @@ type Config struct {
 	// shows up in `/metrics` when at least one source actually parses
 	// PKCS#12 material.
 	Pkcs12InUse            bool
+	// JksInUse mirrors Pkcs12InUse for the JKS / JCEKS parser. When
+	// true, the registry exposes `x509_jks_passphrase_failures_total`.
+	JksInUse               bool
 	SubjectFields          []string
 	IssuerFields           []string
 	TrimPathComponents     int
@@ -95,6 +98,7 @@ type Registry struct {
 	informerQueueDepth       *prometheus.GaugeVec
 	watchResyncs             *prometheus.CounterVec
 	pkcs12PassphraseFailures *prometheus.CounterVec
+	jksPassphraseFailures    *prometheus.CounterVec
 	kubeRequestDuration      *prometheus.HistogramVec
 	buildInfo                prometheus.Gauge
 
@@ -170,6 +174,11 @@ func (r *Registry) initSelfMetrics() {
 	if r.cfg.Pkcs12InUse {
 		r.pkcs12PassphraseFailures = prometheus.NewCounterVec(prometheus.CounterOpts{
 			Name: "x509_pkcs12_passphrase_failures_total", Help: "PKCS#12 decoding attempts failed because of a wrong passphrase.",
+		}, []string{"source_name"})
+	}
+	if r.cfg.JksInUse {
+		r.jksPassphraseFailures = prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "x509_jks_passphrase_failures_total", Help: "JKS / JCEKS decoding attempts failed because of a wrong passphrase.",
 		}, []string{"source_name"})
 	}
 	variadicBuildInfo := product.VariadicBuildInfo()
@@ -275,8 +284,22 @@ func (r *Registry) Delete(ref cert.SourceRef) {
 func (r *Registry) recordBundleErrors(b cert.Bundle) {
 	for _, e := range b.Errors {
 		r.MarkSourceError(b.Source.Kind, b.Source.SourceName, e.Reason)
-		if e.Reason == cert.ReasonBadPassphrase && r.pkcs12PassphraseFailures != nil {
-			r.pkcs12PassphraseFailures.WithLabelValues(b.Source.SourceName).Inc()
+		if e.Reason == cert.ReasonBadPassphrase {
+			// Route to the per-format counter when one is registered.
+			// Format is set on the SourceRef by every parser-aware
+			// emit path (file source, k8s source's secretTypes,
+			// configMaps rule), so dispatching here keeps the two
+			// counters faithful to which decoder actually failed.
+			switch b.Source.Format {
+			case cert.FormatPKCS12:
+				if r.pkcs12PassphraseFailures != nil {
+					r.pkcs12PassphraseFailures.WithLabelValues(b.Source.SourceName).Inc()
+				}
+			case cert.FormatJKS:
+				if r.jksPassphraseFailures != nil {
+					r.jksPassphraseFailures.WithLabelValues(b.Source.SourceName).Inc()
+				}
+			}
 		}
 	}
 }

--- a/pkg/registry/registry_test.go
+++ b/pkg/registry/registry_test.go
@@ -307,20 +307,35 @@ func TestCollisionNeverDedups(t *testing.T) {
 }
 
 func TestRecordBundleErrorsBumpsCounters(t *testing.T) {
-	r := New(Config{Pkcs12InUse: true}, nopLogger())
-	b := cert.Bundle{
-		Source: cert.SourceRef{Kind: "file", Location: "/x.pem", SourceName: "files"},
+	r := New(Config{Pkcs12InUse: true, JksInUse: true}, nopLogger())
+	// PKCS#12 bundle with a bad-passphrase error: routes to
+	// pkcs12PassphraseFailures (not jksPassphraseFailures).
+	r.Upsert(cert.Bundle{
+		Source: cert.SourceRef{Kind: "file", Location: "/x.p12", SourceName: "files", Format: cert.FormatPKCS12},
 		Errors: []cert.ItemError{
 			{Index: -1, Reason: cert.ReasonBadPEM, Err: errors.New("nope")},
 			{Index: -1, Reason: cert.ReasonBadPassphrase, Err: errors.New("nope")},
 		},
-	}
-	r.Upsert(b)
+	})
 	if got := testutil.ToFloat64(r.sourceErrors.WithLabelValues("file", "files", "bad_pem")); got != 1 {
 		t.Errorf("bad_pem counter = %v", got)
 	}
 	if got := testutil.ToFloat64(r.pkcs12PassphraseFailures.WithLabelValues("files")); got != 1 {
 		t.Errorf("pkcs12 passphrase counter = %v", got)
+	}
+	if got := testutil.ToFloat64(r.jksPassphraseFailures.WithLabelValues("files")); got != 0 {
+		t.Errorf("jks passphrase counter must not increment on pkcs12 bundle, got %v", got)
+	}
+	// JKS bundle with a bad-passphrase error: routes to
+	// jksPassphraseFailures.
+	r.Upsert(cert.Bundle{
+		Source: cert.SourceRef{Kind: "file", Location: "/x.jks", SourceName: "files", Format: cert.FormatJKS},
+		Errors: []cert.ItemError{
+			{Index: -1, Reason: cert.ReasonBadPassphrase, Err: errors.New("nope")},
+		},
+	})
+	if got := testutil.ToFloat64(r.jksPassphraseFailures.WithLabelValues("files")); got != 1 {
+		t.Errorf("jks passphrase counter = %v, want 1", got)
 	}
 }
 

--- a/pkg/source/k8s/k8s.go
+++ b/pkg/source/k8s/k8s.go
@@ -109,6 +109,7 @@ type SecretTypeRule struct {
 	Parser              cert.FormatParser
 	ParseOpts           cert.ParseOptions
 	PassphraseKey       string          // when format is pkcs12
+	JksPassphraseKey    string          // when format is jks
 	PassphraseSecretRef *cert.SourceRef // optional cross-secret passphrase ref
 }
 
@@ -823,6 +824,11 @@ func (s *Source) onSecret(sink cert.Sink, obj any, deleted bool) {
 			if rule.PassphraseKey != "" {
 				if pp, ok := sec.Data[rule.PassphraseKey]; ok {
 					po.Pkcs12Passphrase = strings.TrimSpace(string(pp))
+				}
+			}
+			if rule.JksPassphraseKey != "" {
+				if pp, ok := sec.Data[rule.JksPassphraseKey]; ok {
+					po.JksPassphrase = strings.TrimSpace(string(pp))
 				}
 			}
 			b := rule.Parser.Parse(v, ref, po)

--- a/pkg/source/k8s/k8s.go
+++ b/pkg/source/k8s/k8s.go
@@ -823,12 +823,12 @@ func (s *Source) onSecret(sink cert.Sink, obj any, deleted bool) {
 			po := rule.ParseOpts
 			if rule.PassphraseKey != "" {
 				if pp, ok := sec.Data[rule.PassphraseKey]; ok {
-					po.Pkcs12Passphrase = strings.TrimSpace(string(pp))
+					po.Pkcs12Passphrase = strings.TrimRight(string(pp), "\r\n")
 				}
 			}
 			if rule.JksPassphraseKey != "" {
 				if pp, ok := sec.Data[rule.JksPassphraseKey]; ok {
-					po.JksPassphrase = strings.TrimSpace(string(pp))
+					po.JksPassphrase = strings.TrimRight(string(pp), "\r\n")
 				}
 			}
 			b := rule.Parser.Parse(v, ref, po)


### PR DESCRIPTION
Closes #195

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added JKS/JCEKS keystore & truststore support with automatic detection and flexible passphrase sources (inline, file, secret key, or empty-passphrase fallback)
  * New JKS-specific passphrase failure metric (auto-enabled when JKS is configured)

* **Documentation**
  * Updated README, Helm chart docs, and metrics reference to cover JKS/JCEKS usage and new metric

* **Tests**
  * Added unit and fuzz tests for JKS parsing and error cases

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/enix/x509-certificate-exporter/pull/598)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->