### PR TITLE
Fix implementation gaps in JKS/JCEKS/PKCS#12

### DIFF
--- a/pkg/cert/jks/jks.go
+++ b/pkg/cert/jks/jks.go
@@ -34,6 +34,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"sort"
 	"strings"
 
 	"github.com/pavlo-v-chernykh/keystore-go/v4"
@@ -149,7 +150,14 @@ func decodeJKS(data []byte, pass string) ([]itemWithRole, error) {
 		return nil, err
 	}
 	var out []itemWithRole
-	for _, alias := range ks.Aliases() {
+	// Sort aliases so the emitted item order is stable. keystore-go's
+	// Aliases() walks an internal map, which Go iterates in random
+	// order — that randomness leaks into Prometheus metric label
+	// ordering and breaks any downstream test or dashboard that
+	// assumes a stable ordering across exporter restarts.
+	aliases := ks.Aliases()
+	sort.Strings(aliases)
+	for _, alias := range aliases {
 		switch {
 		case ks.IsTrustedCertificateEntry(alias):
 			e, err := ks.GetTrustedCertificateEntry(alias)

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -284,6 +284,18 @@ func (r *Registry) Delete(ref cert.SourceRef) {
 func (r *Registry) recordBundleErrors(b cert.Bundle) {
 	for _, e := range b.Errors {
 		r.MarkSourceError(b.Source.Kind, b.Source.SourceName, e.Reason)
+		args := []any{
+			"source_kind", b.Source.Kind,
+			"source_name", b.Source.SourceName,
+			"location", b.Source.Location,
+			"key", b.Source.Key,
+			"format", b.Source.Format,
+			"reason", e.Reason,
+		}
+		if e.Err != nil {
+			args = append(args, "err", e.Err)
+		}
+		r.logger.Debug("bundle parse error", args...)
 		if e.Reason == cert.ReasonBadPassphrase {
 			// Route to the per-format counter when one is registered.
 			// Format is set on the SourceRef by every parser-aware

--- a/pkg/source/k8s/k8s.go
+++ b/pkg/source/k8s/k8s.go
@@ -846,6 +846,7 @@ func (s *Source) onSecret(ctx context.Context, sink cert.Sink, obj any, deleted 
 					"ref_namespace", secretRef.Namespace, "ref_name", secretRef.Name,
 					"ref_key", secretRef.Key)
 			}
+			passphraseUnavailable := false
 			if rule.PassphraseKey != "" {
 				if pp, ok := sec.Data[rule.PassphraseKey]; ok {
 					po.Pkcs12Passphrase = strings.TrimRight(string(pp), "\r\n")
@@ -853,6 +854,7 @@ func (s *Source) onSecret(ctx context.Context, sink cert.Sink, obj any, deleted 
 					s.log.Debug("passphraseKey not found in secret data",
 						"namespace", sec.Namespace, "name", sec.Name, "format", ref.Format,
 						"passphrase_key", rule.PassphraseKey)
+					passphraseUnavailable = !po.Pkcs12TryEmpty
 				}
 			}
 			if rule.PassphraseSecretRef != nil {
@@ -865,10 +867,21 @@ func (s *Source) onSecret(ctx context.Context, sink cert.Sink, obj any, deleted 
 					s.log.Debug("passphraseKey not found in secret data",
 						"namespace", sec.Namespace, "name", sec.Name, "format", ref.Format,
 						"passphrase_key", rule.JksPassphraseKey)
+					passphraseUnavailable = !po.JksTryEmpty
 				}
 			}
 			if rule.JksPassphraseSecretRef != nil {
 				resolveRef(rule.JksPassphraseSecretRef, &po.JksPassphrase)
+			}
+			if passphraseUnavailable {
+				b := cert.Bundle{Source: ref, Errors: []cert.ItemError{{
+					Index:  -1,
+					Reason: cert.ReasonBadPassphrase,
+					Err:    fmt.Errorf("passphraseKey not found in secret data"),
+				}}}
+				s.trackUpsert(sink, b)
+				emitted++
+				continue
 			}
 			b := rule.Parser.Parse(v, ref, po)
 			s.trackUpsert(sink, b)

--- a/pkg/source/k8s/k8s.go
+++ b/pkg/source/k8s/k8s.go
@@ -831,20 +831,21 @@ func (s *Source) onSecret(ctx context.Context, sink cert.Sink, obj any, deleted 
 			}
 			ref := s.refSecret(sec, k, rule.Parser.Format())
 			po := rule.ParseOpts
-			resolveRef := func(secretRef *PassphraseSecretRef, dest *string) {
+			resolveRef := func(secretRef *PassphraseSecretRef, dest *string) bool {
 				pp, err := s.fetchPassphrase(ctx, secretRef, sec.Namespace)
 				if err != nil {
 					s.log.Info("passphraseSecretRef lookup failed",
 						"namespace", sec.Namespace, "name", sec.Name, "format", ref.Format,
 						"ref_namespace", secretRef.Namespace, "ref_name", secretRef.Name,
 						"ref_key", secretRef.Key, "err", err)
-					return
+					return false
 				}
 				*dest = pp
 				s.log.Debug("passphraseSecretRef resolved",
 					"namespace", sec.Namespace, "name", sec.Name, "format", ref.Format,
 					"ref_namespace", secretRef.Namespace, "ref_name", secretRef.Name,
 					"ref_key", secretRef.Key)
+				return true
 			}
 			passphraseUnavailable := false
 			if rule.PassphraseKey != "" {
@@ -858,7 +859,9 @@ func (s *Source) onSecret(ctx context.Context, sink cert.Sink, obj any, deleted 
 				}
 			}
 			if rule.PassphraseSecretRef != nil {
-				resolveRef(rule.PassphraseSecretRef, &po.Pkcs12Passphrase)
+				if ok := resolveRef(rule.PassphraseSecretRef, &po.Pkcs12Passphrase); !ok {
+					passphraseUnavailable = !po.Pkcs12TryEmpty
+				}
 			}
 			if rule.JksPassphraseKey != "" {
 				if pp, ok := sec.Data[rule.JksPassphraseKey]; ok {
@@ -871,7 +874,9 @@ func (s *Source) onSecret(ctx context.Context, sink cert.Sink, obj any, deleted 
 				}
 			}
 			if rule.JksPassphraseSecretRef != nil {
-				resolveRef(rule.JksPassphraseSecretRef, &po.JksPassphrase)
+				if ok := resolveRef(rule.JksPassphraseSecretRef, &po.JksPassphrase); !ok {
+					passphraseUnavailable = !po.JksTryEmpty
+				}
 			}
 			if passphraseUnavailable {
 				b := cert.Bundle{Source: ref, Errors: []cert.ItemError{{

--- a/pkg/source/k8s/k8s.go
+++ b/pkg/source/k8s/k8s.go
@@ -104,10 +104,10 @@ const (
 // use. KeyRe is compiled from the user-provided regex; one entry per
 // regex.
 type SecretTypeRule struct {
-	Type                string
-	KeyRe               *regexp.Regexp
-	Parser              cert.FormatParser
-	ParseOpts           cert.ParseOptions
+	Type                   string
+	KeyRe                  *regexp.Regexp
+	Parser                 cert.FormatParser
+	ParseOpts              cert.ParseOptions
 	PassphraseKey          string               // when format is pkcs12
 	JksPassphraseKey       string               // when format is jks
 	PassphraseSecretRef    *PassphraseSecretRef // pkcs12: optional cross-Secret passphrase ref
@@ -831,22 +831,28 @@ func (s *Source) onSecret(ctx context.Context, sink cert.Sink, obj any, deleted 
 			}
 			ref := s.refSecret(sec, k, rule.Parser.Format())
 			po := rule.ParseOpts
+			resolveRef := func(secretRef *PassphraseSecretRef, dest *string) {
+				pp, err := s.fetchPassphrase(ctx, secretRef, sec.Namespace)
+				if err != nil {
+					s.log.Info("passphraseSecretRef lookup failed",
+						"namespace", sec.Namespace, "name", sec.Name, "format", ref.Format,
+						"ref_namespace", secretRef.Namespace, "ref_name", secretRef.Name,
+						"ref_key", secretRef.Key, "err", err)
+					return
+				}
+				*dest = pp
+				s.log.Debug("passphraseSecretRef resolved",
+					"namespace", sec.Namespace, "name", sec.Name, "format", ref.Format,
+					"ref_namespace", secretRef.Namespace, "ref_name", secretRef.Name,
+					"ref_key", secretRef.Key)
+			}
 			if rule.PassphraseKey != "" {
 				if pp, ok := sec.Data[rule.PassphraseKey]; ok {
 					po.Pkcs12Passphrase = strings.TrimRight(string(pp), "\r\n")
 				}
 			}
 			if rule.PassphraseSecretRef != nil {
-				if pp, err := s.fetchPassphrase(ctx, rule.PassphraseSecretRef, sec.Namespace); err != nil {
-					s.log.Warn("passphraseSecretRef lookup failed",
-						"namespace", sec.Namespace, "name", sec.Name,
-						"ref_namespace", rule.PassphraseSecretRef.Namespace,
-						"ref_name", rule.PassphraseSecretRef.Name,
-						"ref_key", rule.PassphraseSecretRef.Key,
-						"err", err)
-				} else {
-					po.Pkcs12Passphrase = pp
-				}
+				resolveRef(rule.PassphraseSecretRef, &po.Pkcs12Passphrase)
 			}
 			if rule.JksPassphraseKey != "" {
 				if pp, ok := sec.Data[rule.JksPassphraseKey]; ok {
@@ -854,16 +860,7 @@ func (s *Source) onSecret(ctx context.Context, sink cert.Sink, obj any, deleted 
 				}
 			}
 			if rule.JksPassphraseSecretRef != nil {
-				if pp, err := s.fetchPassphrase(ctx, rule.JksPassphraseSecretRef, sec.Namespace); err != nil {
-					s.log.Warn("jks passphraseSecretRef lookup failed",
-						"namespace", sec.Namespace, "name", sec.Name,
-						"ref_namespace", rule.JksPassphraseSecretRef.Namespace,
-						"ref_name", rule.JksPassphraseSecretRef.Name,
-						"ref_key", rule.JksPassphraseSecretRef.Key,
-						"err", err)
-				} else {
-					po.JksPassphrase = pp
-				}
+				resolveRef(rule.JksPassphraseSecretRef, &po.JksPassphrase)
 			}
 			b := rule.Parser.Parse(v, ref, po)
 			s.trackUpsert(sink, b)

--- a/pkg/source/k8s/k8s.go
+++ b/pkg/source/k8s/k8s.go
@@ -831,58 +831,74 @@ func (s *Source) onSecret(ctx context.Context, sink cert.Sink, obj any, deleted 
 			}
 			ref := s.refSecret(sec, k, rule.Parser.Format())
 			po := rule.ParseOpts
-			resolveRef := func(secretRef *PassphraseSecretRef, dest *string) bool {
+			resolveRef := func(secretRef *PassphraseSecretRef, dest *string) error {
 				pp, err := s.fetchPassphrase(ctx, secretRef, sec.Namespace)
 				if err != nil {
 					s.log.Info("passphraseSecretRef lookup failed",
 						"namespace", sec.Namespace, "name", sec.Name, "format", ref.Format,
 						"ref_namespace", secretRef.Namespace, "ref_name", secretRef.Name,
 						"ref_key", secretRef.Key, "err", err)
-					return false
+					return err
 				}
 				*dest = pp
 				s.log.Debug("passphraseSecretRef resolved",
 					"namespace", sec.Namespace, "name", sec.Name, "format", ref.Format,
 					"ref_namespace", secretRef.Namespace, "ref_name", secretRef.Name,
 					"ref_key", secretRef.Key)
-				return true
+				return nil
 			}
-			passphraseUnavailable := false
-			if rule.PassphraseKey != "" {
-				if pp, ok := sec.Data[rule.PassphraseKey]; ok {
-					po.Pkcs12Passphrase = strings.TrimRight(string(pp), "\r\n")
-				} else {
-					s.log.Debug("passphraseKey not found in secret data",
-						"namespace", sec.Namespace, "name", sec.Name, "format", ref.Format,
-						"passphrase_key", rule.PassphraseKey)
-					passphraseUnavailable = !po.Pkcs12TryEmpty
+			tryKey := func(passphraseKey string, dest *string) error {
+				if pp, ok := sec.Data[passphraseKey]; ok {
+					*dest = strings.TrimRight(string(pp), "\r\n")
+					return nil
 				}
+				s.log.Debug("passphraseKey not found in secret data",
+					"namespace", sec.Namespace, "name", sec.Name, "format", ref.Format,
+					"passphrase_key", passphraseKey)
+				return fmt.Errorf("passphraseKey %q not found in secret data", passphraseKey)
+			}
+			// Per-rule passphrase resolution. A rule is mono-format
+			// (Parser.Format()), so only the matching pair of fields is
+			// populated by the wiring layer — the other pair is zero
+			// values that no-op here. The bundle error preserves the
+			// concrete cause (missing key vs failed SecretRef lookup)
+			// of the last failed source, so the operator sees a useful
+			// reason in metrics + logs instead of a generic message.
+			passphraseAttempted := false
+			passphraseObtained := false
+			var passphraseErr error
+			recordResult := func(err error) {
+				passphraseAttempted = true
+				if err == nil {
+					passphraseObtained = true
+					return
+				}
+				passphraseErr = err
+			}
+			if rule.PassphraseKey != "" {
+				recordResult(tryKey(rule.PassphraseKey, &po.Pkcs12Passphrase))
 			}
 			if rule.PassphraseSecretRef != nil {
-				if ok := resolveRef(rule.PassphraseSecretRef, &po.Pkcs12Passphrase); !ok {
-					passphraseUnavailable = !po.Pkcs12TryEmpty
-				}
+				recordResult(resolveRef(rule.PassphraseSecretRef, &po.Pkcs12Passphrase))
 			}
 			if rule.JksPassphraseKey != "" {
-				if pp, ok := sec.Data[rule.JksPassphraseKey]; ok {
-					po.JksPassphrase = strings.TrimRight(string(pp), "\r\n")
-				} else {
-					s.log.Debug("passphraseKey not found in secret data",
-						"namespace", sec.Namespace, "name", sec.Name, "format", ref.Format,
-						"passphrase_key", rule.JksPassphraseKey)
-					passphraseUnavailable = !po.JksTryEmpty
-				}
+				recordResult(tryKey(rule.JksPassphraseKey, &po.JksPassphrase))
 			}
 			if rule.JksPassphraseSecretRef != nil {
-				if ok := resolveRef(rule.JksPassphraseSecretRef, &po.JksPassphrase); !ok {
-					passphraseUnavailable = !po.JksTryEmpty
-				}
+				recordResult(resolveRef(rule.JksPassphraseSecretRef, &po.JksPassphrase))
 			}
-			if passphraseUnavailable {
+			tryEmpty := false
+			switch ref.Format {
+			case cert.FormatPKCS12:
+				tryEmpty = po.Pkcs12TryEmpty
+			case cert.FormatJKS:
+				tryEmpty = po.JksTryEmpty
+			}
+			if passphraseAttempted && !passphraseObtained && !tryEmpty {
 				b := cert.Bundle{Source: ref, Errors: []cert.ItemError{{
 					Index:  -1,
 					Reason: cert.ReasonBadPassphrase,
-					Err:    fmt.Errorf("passphraseKey not found in secret data"),
+					Err:    passphraseErr,
 				}}}
 				s.trackUpsert(sink, b)
 				emitted++

--- a/pkg/source/k8s/k8s.go
+++ b/pkg/source/k8s/k8s.go
@@ -849,6 +849,10 @@ func (s *Source) onSecret(ctx context.Context, sink cert.Sink, obj any, deleted 
 			if rule.PassphraseKey != "" {
 				if pp, ok := sec.Data[rule.PassphraseKey]; ok {
 					po.Pkcs12Passphrase = strings.TrimRight(string(pp), "\r\n")
+				} else {
+					s.log.Debug("passphraseKey not found in secret data",
+						"namespace", sec.Namespace, "name", sec.Name, "format", ref.Format,
+						"passphrase_key", rule.PassphraseKey)
 				}
 			}
 			if rule.PassphraseSecretRef != nil {
@@ -857,6 +861,10 @@ func (s *Source) onSecret(ctx context.Context, sink cert.Sink, obj any, deleted 
 			if rule.JksPassphraseKey != "" {
 				if pp, ok := sec.Data[rule.JksPassphraseKey]; ok {
 					po.JksPassphrase = strings.TrimRight(string(pp), "\r\n")
+				} else {
+					s.log.Debug("passphraseKey not found in secret data",
+						"namespace", sec.Namespace, "name", sec.Name, "format", ref.Format,
+						"passphrase_key", rule.JksPassphraseKey)
 				}
 			}
 			if rule.JksPassphraseSecretRef != nil {

--- a/pkg/source/k8s/k8s.go
+++ b/pkg/source/k8s/k8s.go
@@ -229,7 +229,7 @@ func New(opts Options, logger *slog.Logger) *Source {
 	}
 	return &Source{
 		opts:            opts,
-		log:             logger.With("source_kind", "kubernetes", "source_name", opts.Name),
+		log:             logger.With("source_name", opts.Name),
 		tracked:         map[string]struct{}{},
 		nsLabels:        map[string]map[string]string{},
 		nsLabelsChanged: make(chan struct{}, 1),

--- a/pkg/source/k8s/k8s_passphrase_test.go
+++ b/pkg/source/k8s/k8s_passphrase_test.go
@@ -47,6 +47,15 @@ func (p *recordingParser) lastOpts(t *testing.T) cert.ParseOptions {
 	return p.opts[len(p.opts)-1]
 }
 
+func (p *recordingParser) assertNotCalled(t *testing.T) {
+	t.Helper()
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if len(p.opts) > 0 {
+		t.Fatalf("parser was called %d time(s), expected none", len(p.opts))
+	}
+}
+
 // newSource builds a minimal Source whose only purpose is to drive
 // onSecret directly. Bypasses Run() to avoid the LIST+WATCH event loop
 // — these tests target the rule→passphrase resolution logic and the
@@ -111,10 +120,11 @@ func TestPassphraseSecretRefExplicitNamespace(t *testing.T) {
 	}
 }
 
-func TestPassphraseSecretRefMissingSecretLogsAndContinues(t *testing.T) {
-	// The passphrase Secret does not exist. Source must log and call the
-	// parser anyway (with empty Pkcs12Passphrase) — a sane PKCS#12 parser
-	// will surface bad_passphrase, but that's the parser's job.
+func TestPassphraseSecretRefMissingSecretSkipsParseWhenTryEmptyFalse(t *testing.T) {
+	// The passphrase Secret does not exist and tryEmptyPassphrase is false
+	// (default). The source must NOT call the parser — it emits a
+	// bad_passphrase bundle error directly rather than silently falling
+	// through to an empty-passphrase attempt.
 	certSec := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{Name: "tls", Namespace: "ns"},
 		Type:       corev1.SecretType("kubernetes.io/tls"),
@@ -128,14 +138,37 @@ func TestPassphraseSecretRefMissingSecretLogsAndContinues(t *testing.T) {
 		Parser:              parser,
 	}
 	src := newSource(t, rule, certSec)
+	sink := &fakeSink{}
+	src.onSecret(context.Background(), sink, certSec, false)
+
+	parser.assertNotCalled(t)
+}
+
+func TestPassphraseSecretRefMissingSecretContinuesWhenTryEmptyTrue(t *testing.T) {
+	// Same setup, but tryEmptyPassphrase: true — source must still call the
+	// parser (with empty passphrase) so the parser can decide the outcome.
+	certSec := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "tls", Namespace: "ns"},
+		Type:       corev1.SecretType("kubernetes.io/tls"),
+		Data:       map[string][]byte{"keystore.p12": []byte("blob")},
+	}
+	parser := &recordingParser{}
+	rule := SecretTypeRule{
+		Type:                "kubernetes.io/tls",
+		KeyRe:               regexp.MustCompile(`^keystore\.p12$`),
+		PassphraseSecretRef: &PassphraseSecretRef{Name: "missing", Key: "pp"},
+		ParseOpts:           cert.ParseOptions{Pkcs12TryEmpty: true},
+		Parser:              parser,
+	}
+	src := newSource(t, rule, certSec)
 	src.onSecret(context.Background(), &fakeSink{}, certSec, false)
 
 	if got := parser.lastOpts(t).Pkcs12Passphrase; got != "" {
-		t.Fatalf("Pkcs12Passphrase = %q, want empty (missing ref)", got)
+		t.Fatalf("Pkcs12Passphrase = %q, want empty", got)
 	}
 }
 
-func TestPassphraseSecretRefMissingKeyLogsAndContinues(t *testing.T) {
+func TestPassphraseSecretRefMissingKeySkipsParseWhenTryEmptyFalse(t *testing.T) {
 	certSec := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{Name: "tls", Namespace: "ns"},
 		Type:       corev1.SecretType("kubernetes.io/tls"),
@@ -155,9 +188,7 @@ func TestPassphraseSecretRefMissingKeyLogsAndContinues(t *testing.T) {
 	src := newSource(t, rule, certSec, ppSec)
 	src.onSecret(context.Background(), &fakeSink{}, certSec, false)
 
-	if got := parser.lastOpts(t).Pkcs12Passphrase; got != "" {
-		t.Fatalf("Pkcs12Passphrase = %q, want empty (key missing)", got)
-	}
+	parser.assertNotCalled(t)
 }
 
 func TestJksPassphraseSecretRefSameNamespace(t *testing.T) {


### PR DESCRIPTION
We had gaps in the implementation of JKS/JCEKS/PKCS#12 bundles, with code paths ignoring formats or features such as passphrase to secret references.
Also, improve logging messages to give visibility on passphrase lookup and decryption failure reasons.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More robust handling of missing/invalid certificate passphrases for Kubernetes secrets — parsing is skipped and a clear "bad passphrase" result is produced instead of attempting parsing with empty values.
  * Parser is no longer invoked when passphrase material is unavailable (avoids misleading outcomes).

* **Improvements**
  * Enhanced structured debug logs for bundle parsing errors with richer context.
  * Keystore entries are emitted in a consistent, stable order.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/enix/x509-certificate-exporter/pull/612?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->