### PR TITLE
build: use goreleaser v2.16 new features

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -232,6 +232,14 @@ dockers_v2:
       org.opencontainers.image.revision: "{{ .FullCommit }}"
       org.opencontainers.image.created: "{{ .Date }}"
       org.opencontainers.image.licenses: "MIT"
+      # Resolved by GoReleaser from the FROM line in
+      # build/Dockerfile.busybox at build time. Surfaces the exact base
+      # image identity in every published manifest — supply-chain
+      # transparency without manual bookkeeping. Skipped on the scratch
+      # variant: `FROM scratch` has no parent and these labels would be
+      # empty.
+      org.opencontainers.image.base.name: "{{ .BaseImage }}"
+      org.opencontainers.image.base.digest: "{{ .BaseImageDigest }}"
 
   - id: busybox-local
     disable: '{{ if eq (envOrDefault "GORELEASER_LOCAL_PLATFORM" "") "1" }}{{ else }}true{{ end }}'
@@ -257,6 +265,14 @@ dockers_v2:
   # Tilt sets via the wrapper script in the Tiltfile, so the resulting
   # image lands in local Docker under exactly the ref Tilt expects
   # (skips_local_docker=False).
+  #
+  # The post hook re-tags the image to drop the `-<arch>` suffix that
+  # dockers_v2 appends in snapshot mode. Tilt expects to find the image
+  # at exactly `EXPECTED_REF` (TILT_IMAGE_REPO:TILT_IMAGE_TAG), without
+  # any arch annotation. Living inside .goreleaser.yaml (not the
+  # Tiltfile) keeps the snapshot-mode quirk and its remedy in the same
+  # file — Tilt just runs `goreleaser release ...` and trusts the
+  # result.
   - id: tilt
     disable: '{{ if eq (envOrDefault "GORELEASER_TILT" "") "1" }}{{ else }}true{{ end }}'
     ids: [x509ce-local]
@@ -269,6 +285,9 @@ dockers_v2:
       - '{{ envOrDefault "TILT_IMAGE_TAG" "tilt" }}'
     sbom: false
     labels: *busybox-labels
+    hooks:
+      post:
+        - cmd: docker tag {{ envOrDefault "TILT_IMAGE_REPO" "x509-certificate-exporter" }}:{{ envOrDefault "TILT_IMAGE_TAG" "tilt" }}-{{ .Runtime.Goarch }} {{ envOrDefault "TILT_IMAGE_REPO" "x509-certificate-exporter" }}:{{ envOrDefault "TILT_IMAGE_TAG" "tilt" }}
 
 # ─── Cosign on container images ──────────────────────────────────────────────
 # Sign by digest (anchored to immutable content). Consumers verify the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -185,11 +185,11 @@ On any change Tilt invokes `goreleaser release --snapshot ...` with
 `GORELEASER_TILT=1`, which builds a single host-arch image from
 `build/Dockerfile.busybox` (the alt release variant — kept for dev
 because it ships a shell, even though scratch is the project default)
-and loads it into the local Docker daemon. A `docker tag` post-step strips the
-`-<arch>` suffix that dockers_v2 appends in snapshot mode so Tilt
-finds the image at exactly `EXPECTED_REF`. Tilt then pushes to the
-local registry; Helm is reconfigured with the new tag and the pod
-restarts.
+and loads it into the local Docker daemon. A `hooks.post` on the
+tilt dockers_v2 entry strips the `-<arch>` suffix that dockers_v2
+appends in snapshot mode so Tilt finds the image at exactly
+`EXPECTED_REF`. Tilt then pushes to the local registry; Helm is
+reconfigured with the new tag and the pod restarts.
 
 Forwarded ports:
 

--- a/Tiltfile
+++ b/Tiltfile
@@ -49,10 +49,10 @@ KUBE_PROMETHEUS_VERSION = "85.3.3"
 #   - builds only the host arch + only this variant,
 #   - tags directly with what Tilt expects via TILT_IMAGE_REPO/TAG.
 #
-# GoReleaser's dockers_v2 appends a `-<arch>` suffix to local tags in
-# snapshot mode (anti-collision when buildx loads multi-platform
-# images into Docker). The `docker tag` re-aliases to the bare
-# EXPECTED_REF Tilt expects (skips_local_docker=False).
+# The `-<arch>` suffix that dockers_v2 appends in snapshot mode is
+# stripped by a `hooks.post` on the tilt entry inside .goreleaser.yaml,
+# so the image lands in local Docker under exactly EXPECTED_REF
+# (skips_local_docker=False).
 custom_build(
     ref=IMAGE,
     command=" && ".join(
@@ -62,7 +62,6 @@ custom_build(
             "export GORELEASER_TILT=1",
             "export IMAGE_NAME=x509-certificate-exporter",
             "goreleaser release --snapshot --skip=publish,sign,sbom,archive,before --clean",
-            'docker tag "${EXPECTED_REF}-$(go env GOARCH)" "$EXPECTED_REF"',
         ]
     ),
     deps=[

--- a/flake.nix
+++ b/flake.nix
@@ -49,6 +49,40 @@
             install -Dm755 gsa $out/bin/gsa
           '';
         };
+
+        # GoReleaser pinned independently of nixpkgs so the dev/e2e
+        # build path can adopt new releases as soon as upstream ships
+        # them. Grabs the upstream binary release rather than rebuilding
+        # via `buildGoModule` — same trade-off as goSizeAnalyzer above.
+        #
+        # Bump procedure (Renovate refreshes `version` but cannot
+        # recompute the four per-arch hashes on a `fetchurl` bump):
+        #   1. update `version` below
+        #   2. curl -sL https://github.com/goreleaser/goreleaser/releases/download/v<v>/checksums.txt
+        #   3. for each `goreleaser_<OS>_<arch>.tar.gz` line, convert:
+        #      `hash = "sha256-$(echo <hex> | xxd -r -p | base64)"`
+        goreleaser = let
+          # goreleaser version
+          version = "2.16.0";
+          assets = {
+            "x86_64-linux"   = { suffix = "Linux_x86_64";  hash = "sha256-6q4FteugdTO9DwaEa2jICDmVBHhN8Axi6yGVQfwE5eI="; };
+            "aarch64-linux"  = { suffix = "Linux_arm64";   hash = "sha256-AQLZdDc/zet3BC0fWJfK/6GTvjZiD9xsHaQ6Ae+OENM="; };
+            "x86_64-darwin"  = { suffix = "Darwin_x86_64"; hash = "sha256-K4LYMZ7lF9QkK0ioWBFLJnxiHx3R/lGhRoCQKxil2sg="; };
+            "aarch64-darwin" = { suffix = "Darwin_arm64";  hash = "sha256-j2iYJW81UxFl2Q8ttYHF7g0yvag+vCWsIx/1vbnSBxo="; };
+          };
+          asset = assets.${system} or (throw "goreleaser: unsupported system ${system}");
+        in pkgs.stdenvNoCC.mkDerivation {
+          pname = "goreleaser";
+          inherit version;
+          src = pkgs.fetchurl {
+            url = "https://github.com/goreleaser/goreleaser/releases/download/v${version}/goreleaser_${asset.suffix}.tar.gz";
+            hash = asset.hash;
+          };
+          sourceRoot = ".";
+          installPhase = ''
+            install -Dm755 goreleaser $out/bin/goreleaser
+          '';
+        };
       in {
         devShells.default = pkgs.mkShell {
           # Go is intentionally unpinned: the dev shell ships whatever Go
@@ -58,10 +92,10 @@
           packages = [
             dagger.packages.${system}.dagger
             goSizeAnalyzer
+            goreleaser
           ] ++ (with pkgs; [
             go
             go-task
-            goreleaser
             tilt
             k3d
             kubectl

--- a/renovate.json5
+++ b/renovate.json5
@@ -186,6 +186,22 @@
       depNameTemplate: "goreleaser/goreleaser",
       datasourceTemplate: "github-releases",
     },
+    // GoReleaser version pinned in flake.nix (the dev shell installs
+    // the upstream binary release rather than the nixpkgs build). Same
+    // depName as the CI pin above — a single Renovate PR bumps every
+    // reference. Per-arch hashes in flake.nix still need manual refresh
+    // on bump (documented in the bump procedure comment alongside the
+    // declaration, mirroring the goSizeAnalyzer recipe).
+    {
+      customType: "regex",
+      managerFilePatterns: ["/^flake\\.nix$/"],
+      matchStrings: [
+        "# goreleaser version\\s*\\n\\s*version\\s*=\\s*\"(?<currentValue>\\d[\\w.-]*)\"",
+      ],
+      depNameTemplate: "goreleaser/goreleaser",
+      datasourceTemplate: "github-releases",
+      extractVersionTemplate: "^v(?<version>.*)$",
+    },
     // Helm version pinned inside the `with: version:` field of
     // azure/setup-helm in release.yaml (same blind spot as goreleaser above).
     {

--- a/test/e2e/Tiltfile
+++ b/test/e2e/Tiltfile
@@ -54,7 +54,10 @@ SEED_HOSTPATH_IMAGE = "x509ce-seed-hostpath"
 # the release pipeline (one image-build codepath for dev + e2e + release).
 # See the dev Tiltfile for the full rationale. The custom_build command
 # `cd`s to the repo root so the goreleaser config + the binaries land
-# where its dockers_v2 entry expects them.
+# where its dockers_v2 entry expects them. The `-<arch>` suffix that
+# dockers_v2 appends in snapshot mode is stripped by a `hooks.post` on
+# the tilt entry inside .goreleaser.yaml, so the image lands in local
+# Docker under exactly EXPECTED_REF (skips_local_docker=False).
 custom_build(
     ref=IMAGE,
     command=" && ".join([
@@ -64,7 +67,6 @@ custom_build(
         'export GORELEASER_TILT=1',
         'export IMAGE_NAME=x509-certificate-exporter',
         'goreleaser release --snapshot --skip=publish,sign,sbom,archive,before --clean',
-        'docker tag "${EXPECTED_REF}-$(go env GOARCH)" "$EXPECTED_REF"',
     ]),
     deps=[
         ROOT + "/cmd",


### PR DESCRIPTION
- dockers_v2.hooks.post on the tilt entry strips the -<arch> suffix dockers_v2 appends in snapshot mode, keeping the workaround colocated with the build config instead of in the Tiltfile.
- baseimage/baseimagedigest template variables (new in v2.16) populate org.opencontainers.image.base.name/digest on the busybox variant for supply-chain transparency. Scratch is skipped — FROM scratch has no parent and the labels would be empty.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated developer docs to reflect the new dev-image retagging behavior so local dev loops work without manual re-tag steps.

* **Chores**
  * Enriched published container image labels with base-image identity metadata for better traceability.
  * Automated the dev-image re-tagging in the build flow to match local dev tooling expectations.
  * Updated dev tooling configuration to pin the release tool and enable automated version updates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/enix/x509-certificate-exporter/pull/613?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->