### PR TITLE
helm: add option to set grafana dashboard namespace

### DIFF
--- a/chart/README.md
+++ b/chart/README.md
@@ -305,6 +305,7 @@ exporter-toolkit is the recommended path on new installs.
 | exposeDiagnosticMetrics | bool | `false` | Expose self-introspection metrics for debugging the exporter itself (`x509_parse_duration_seconds`, `x509_kube_request_duration_seconds`, `x509_kube_informer_scope`, `x509_informer_queue_depth`). Off by default ; enable when you actually need to look inside. |
 | metricLabelsFilterList | list | `nil` | Restrict metric labels to this list if set. **Warning** : use with caution as reducing cardinality may yield metrics collisions and force the exporter to ignore certificates. This will also degrade the usability of the Grafana dashboard. This list should always include at least `filepath`, `secret_namespace` and `secret_name`. Also `subject_CN` is highly recommended for when a file contains multiple certificates. |
 | grafana.createDashboard | bool | `false` | Should the Grafana dashboard be deployed as a ConfigMap (requires Grafana sidecar) |
+| grafana.dashboardNamespace | string | `nil` | Namespace to create ConfigMap if. Omit to use same namespace as release. |
 | grafana.sidecarLabel | string | `"grafana_dashboard"` | ConfigMap label name the Grafana sidecar is looking for |
 | grafana.sidecarLabelValue | string | `"1"` | ConfigMap label value the Grafana sidecar is looking for |
 | grafana.annotations | object | `{}` | Annotations added to the Grafana dashboard ConfigMap (example in `values.yaml`) |

--- a/chart/templates/grafana-dashboard.configmap.yaml
+++ b/chart/templates/grafana-dashboard.configmap.yaml
@@ -5,7 +5,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ printf "%s-%s" (include "x509-certificate-exporter.fullname" $) "dashboard" | trunc 63 | trimSuffix "-" }}
-  namespace: {{ include "x509-certificate-exporter.namespace" . }}
+  namespace: {{ .Values.grafana.dashboardNamespace | default (include "x509-certificate-exporter.namespace" .) }}
   labels:
     {{- include "x509-certificate-exporter.labels" . | nindent 4 }}
     {{ .Values.grafana.sidecarLabel | quote }}: {{ .Values.grafana.sidecarLabelValue | quote }}

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -160,8 +160,15 @@
           "type": "boolean"
         },
         "dashboardNamespace": {
-          "default": null,
-          "type": ["string", "null"]
+          "default": "null",
+          "maxLength": 63,
+          "minLength": 1,
+          "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
+          "required": [],
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "extraLabels": {
           "additionalProperties": true,

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -159,6 +159,10 @@
           "default": false,
           "type": "boolean"
         },
+        "dashboardNamespace": {
+          "default": null,
+          "type": ["string", "null"]
+        },
         "extraLabels": {
           "additionalProperties": true,
           "required": []

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -124,6 +124,8 @@ metricLabelsFilterList: null
 grafana:
   # -- Should the Grafana dashboard be deployed as a ConfigMap (requires Grafana sidecar)
   createDashboard: false
+  # -- Namespace to create ConfigMap if. Omit to use same namespace as release.
+  dashboardNamespace: ~
   # -- ConfigMap label name the Grafana sidecar is looking for
   sidecarLabel: grafana_dashboard
   # -- ConfigMap label value the Grafana sidecar is looking for

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -124,8 +124,14 @@ metricLabelsFilterList: null
 grafana:
   # -- Should the Grafana dashboard be deployed as a ConfigMap (requires Grafana sidecar)
   createDashboard: false
+  # @schema
+  # type: [string, 'null']
+  # minLength: 1
+  # maxLength: 63
+  # pattern: '^[a-z]([-a-z0-9]*[a-z0-9])?$'
+  # @schema
   # -- Namespace to create ConfigMap if. Omit to use same namespace as release.
-  dashboardNamespace: ~
+  dashboardNamespace: null
   # -- ConfigMap label name the Grafana sidecar is looking for
   sidecarLabel: grafana_dashboard
   # -- ConfigMap label value the Grafana sidecar is looking for


### PR DESCRIPTION
This patch adds a new helm value `grafana.dashboardNamespace` which sets the namespace of the dashboard configmap. This is intended to support the use case where the ConfigMaps live in a separate namespace that is world readable, a primary example being Rancher's "cattle-dashboards" namespace.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `grafana.dashboardNamespace` option to control the namespace used for the Grafana dashboard ConfigMap. Set it to an explicit, Kubernetes-compatible namespace name, or set it to `null`/leave it unset to use the release namespace.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->