### PR TITLE
feat(registry): pre-initialise counter series at zero per source

### DIFF
--- a/cmd/x509-certificate-exporter/main.go
+++ b/cmd/x509-certificate-exporter/main.go
@@ -198,6 +198,7 @@ func run() error {
 		if err != nil {
 			return fmt.Errorf("source %q: %w", s.Name, err)
 		}
+		preInitSourceMetrics(reg, s)
 		logger.Debug("starting source", "source_name", s.Name, "source_kind", s.Kind)
 		go func() {
 			defer recoverPanic(reg, "source/"+s.Name, logger)
@@ -293,6 +294,48 @@ func recoverPanic(r *registry.Registry, component string, logger *slog.Logger) {
 	if rv := recover(); rv != nil {
 		logger.Error("goroutine panic", "component", component, "panic", fmt.Sprint(rv))
 		r.MarkPanic(component)
+	}
+}
+
+// preInitSourceMetrics materialises the counter series a source is
+// expected to emit, at zero, before any actual event has fired. Without
+// this, an exporter running cleanly shows no series at all for
+// x509_source_errors_total / x509_kube_transport_errors_total / etc.
+// — dashboards display gaps, `rate()` produces nothing until the
+// second event, and operators can't distinguish "healthy" from "metric
+// not reporting".
+//
+// Mapping from a config.Source kind to the registry kinds it emits to:
+//   - kubernetes: kube-secret + kube-configmap (and the kube transport
+//     metrics under (source_name, resource, reason)).
+//   - file:       file
+//   - kubeconfig: kubeconfig
+//   - cabundle:   kube-cabundle
+//
+// For kubernetes sources we additionally pre-init the watch_resyncs /
+// transport_errors families for every resource the source is wired to
+// watch (Secrets, ConfigMaps, and the namespace informer when label-
+// based namespace filters require it).
+func preInitSourceMetrics(reg *registry.Registry, s config.Source) {
+	switch s.Kind {
+	case config.KindKubernetes:
+		var resources []string
+		if s.Secrets != nil {
+			reg.PreInitBundleSource(cert.KindKubeSecret, s.Name)
+			resources = append(resources, "secrets")
+		}
+		if s.ConfigMaps != nil {
+			reg.PreInitBundleSource(cert.KindKubeConfigMap, s.Name)
+			resources = append(resources, "configmaps")
+		}
+		nsInformer := s.Namespaces != nil && (len(s.Namespaces.IncludeLabels) > 0 || len(s.Namespaces.ExcludeLabels) > 0)
+		reg.PreInitKubeTransport(s.Name, resources, nsInformer)
+	case config.KindFile:
+		reg.PreInitBundleSource(cert.KindFile, s.Name)
+	case config.KindKubeconfig:
+		reg.PreInitBundleSource(cert.KindKubeconfig, s.Name)
+	case config.KindCABundle:
+		reg.PreInitBundleSource(cert.KindKubeCABundle, s.Name)
 	}
 }
 

--- a/pkg/cert/reason.go
+++ b/pkg/cert/reason.go
@@ -44,3 +44,48 @@ const (
 	ReasonWatchFlapped       = "watch_flapped"
 	ReasonNamespaceSyncFail  = "namespace_sync_failed"
 )
+
+// BundleReasons enumerates every static reason that may appear as a
+// label on `x509_source_errors_total`. Used by Registry pre-init to
+// materialise counter series at zero so they show up in /metrics and
+// in rate()/increase() the moment the first event lands — without
+// it, the absence-of-series ambiguity ("counter at 0" vs. "metric not
+// reporting") leaks into dashboards and alerts.
+//
+// HTTP-status reasons (`http_NNN`) are deliberately excluded — they're
+// dynamic and would require enumerating every code that the kube
+// apiserver might surface. Alerts aggregating across `reason` (the
+// pattern used by the chart's SourceErrors[Sustained] alert) still see
+// the static-reason baseline series, so the alert query is well-defined
+// before any error has fired.
+var BundleReasons = []string{
+	ReasonBadPEM,
+	ReasonBadCRL,
+	ReasonBadDER,
+	ReasonBadJKS,
+	ReasonBadPKCS12,
+	ReasonBadPassphrase,
+	ReasonNoCertificateFound,
+	ReasonReadFailed,
+	ReasonPermissionDenied,
+	ReasonNotFound,
+	ReasonAPIError,
+	ReasonDecodeFailed,
+	ReasonBrokenSymlink,
+	ReasonOutOfScopeSymlink,
+	ReasonParseTimeout,
+	ReasonWalkError,
+	ReasonRateLimited,
+}
+
+// KubeTransportPerResourceReasons enumerates the static reasons that
+// may appear as the `reason` label of `x509_kube_transport_errors_total`
+// for `resource in {secrets, configmaps}`. The namespace-informer
+// reason is separate (a single `namespace_sync_failed` value bound to
+// `resource="namespaces"`); see Registry.PreInitKubeTransport.
+var KubeTransportPerResourceReasons = []string{
+	ReasonListFailed,
+	ReasonWatchStartFailed,
+	ReasonWatchErrorEvent,
+	ReasonWatchFlapped,
+}

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -455,6 +455,69 @@ func (r *Registry) MarkTransportError(sourceName, resource, reason string) {
 	r.transportErrors.WithLabelValues(sourceName, resource, reason).Inc()
 }
 
+// PreInitBundleSource materialises counter series at zero for a source
+// that emits bundles under (kind, name). Without this, a CounterVec
+// series only appears the first time an event fires — so an exporter
+// that has been running cleanly shows no `x509_source_errors_total`
+// series at all, which dashboards and `rate()`/`increase()` cannot
+// distinguish from "metric not reporting". After pre-init the alert
+// query already sees a baseline of 0 for every static reason; the
+// first real event makes `increase()` jump immediately on the next
+// scrape rather than waiting for two samples.
+//
+// Materialises:
+//   - x509_source_errors_total{source_kind=kind, source_name=name,
+//     reason=...} for every reason in cert.BundleReasons.
+//   - x509_cert_collision_total{source_kind=kind} and
+//     x509_cert_collision_dropped_total{source_kind=kind}.
+//   - x509_{pkcs12,jks}_passphrase_failures_total{source_name=name}
+//     when the corresponding format is in use cluster-wide
+//     (Pkcs12InUse / JksInUse on Config). The conservative choice is
+//     to pre-init for every source even though only sources that
+//     actually parse those formats will ever bump them — series
+//     cardinality is bounded by source count, which is small.
+//
+// Safe to call multiple times; WithLabelValues is idempotent.
+func (r *Registry) PreInitBundleSource(kind, name string) {
+	for _, reason := range cert.BundleReasons {
+		r.sourceErrors.WithLabelValues(kind, name, reason)
+	}
+	r.collisionTotal.WithLabelValues(kind)
+	r.collisionDropped.WithLabelValues(kind)
+	if r.pkcs12PassphraseFailures != nil {
+		r.pkcs12PassphraseFailures.WithLabelValues(name)
+	}
+	if r.jksPassphraseFailures != nil {
+		r.jksPassphraseFailures.WithLabelValues(name)
+	}
+}
+
+// PreInitKubeTransport materialises the Kubernetes-source transport
+// counter series at zero for the given source name. Companion to
+// PreInitBundleSource for k8s sources.
+//
+// Materialises:
+//   - x509_kube_watch_resyncs_total{source_name=name, resource=...}
+//   - x509_kube_transport_errors_total{source_name=name, resource=...,
+//     reason=...} for every reason in cert.KubeTransportPerResourceReasons.
+//   - When namespaceInformer is true, additionally materialises the
+//     namespace-informer resync + transport-error series
+//     (resource="namespaces", reason="namespace_sync_failed").
+//
+// Safe to call multiple times.
+func (r *Registry) PreInitKubeTransport(name string, resources []string, namespaceInformer bool) {
+	for _, resource := range resources {
+		r.watchResyncs.WithLabelValues(name, resource)
+		for _, reason := range cert.KubeTransportPerResourceReasons {
+			r.transportErrors.WithLabelValues(name, resource, reason)
+		}
+	}
+	if namespaceInformer {
+		r.watchResyncs.WithLabelValues(name, "namespaces")
+		r.transportErrors.WithLabelValues(name, "namespaces", cert.ReasonNamespaceSyncFail)
+	}
+}
+
 // snapshot copies the bundles map under the read lock.
 func (r *Registry) snapshot() []cert.Bundle {
 	r.mu.RLock()

--- a/pkg/registry/registry_test.go
+++ b/pkg/registry/registry_test.go
@@ -368,6 +368,105 @@ func TestMarkTransportError(t *testing.T) {
 	}
 }
 
+// TestPreInitMaterializesZeroSeries is the regression net for the
+// "no series until first event" UX hit: it asserts that every counter
+// series we promise to expose for a given (kind, name) exists at zero
+// after PreInitBundleSource + PreInitKubeTransport, so dashboards and
+// alerts see a defined baseline before any error has fired.
+func TestPreInitMaterializesZeroSeries(t *testing.T) {
+	reasons := len(cert.KubeTransportPerResourceReasons)
+	cases := []struct {
+		name          string
+		resources     []string
+		nsInformer    bool
+		wantTransport int // x509_kube_transport_errors_total series
+		wantResyncs   int // x509_kube_watch_resyncs_total series
+	}{
+		{
+			name:          "secrets+configmaps with namespace informer",
+			resources:     []string{"secrets", "configmaps"},
+			nsInformer:    true,
+			wantTransport: reasons*2 + 1, // 2 resources × reasons + namespaces
+			wantResyncs:   3,             // 2 resources + namespaces
+		},
+		{
+			name:          "secrets only, no namespace informer",
+			resources:     []string{"secrets"},
+			nsInformer:    false,
+			wantTransport: reasons,
+			wantResyncs:   1,
+		},
+		{
+			name:          "configmaps only, no namespace informer",
+			resources:     []string{"configmaps"},
+			nsInformer:    false,
+			wantTransport: reasons,
+			wantResyncs:   1,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := New(Config{Pkcs12InUse: true, JksInUse: true}, nopLogger())
+			r.PreInitBundleSource(cert.KindKubeSecret, "kube")
+			r.PreInitKubeTransport("kube", tc.resources, tc.nsInformer)
+
+			reg := prometheus.NewRegistry()
+			if err := reg.Register(r); err != nil {
+				t.Fatal(err)
+			}
+			mfs, err := reg.Gather()
+			if err != nil {
+				t.Fatal(err)
+			}
+			got := map[string]int{} // metric name → series count
+			for _, mf := range mfs {
+				got[*mf.Name] = len(mf.Metric)
+			}
+
+			// Bundle-source series are independent of the transport
+			// permutation: one series per reason, one collision pair per
+			// source_kind, one passphrase series per source_name.
+			if n := got["x509_source_errors_total"]; n != len(cert.BundleReasons) {
+				t.Errorf("x509_source_errors_total: got %d series, want %d", n, len(cert.BundleReasons))
+			}
+			if n := got["x509_cert_collision_total"]; n != 1 {
+				t.Errorf("x509_cert_collision_total: got %d, want 1", n)
+			}
+			if n := got["x509_cert_collision_dropped_total"]; n != 1 {
+				t.Errorf("x509_cert_collision_dropped_total: got %d, want 1", n)
+			}
+			if n := got["x509_pkcs12_passphrase_failures_total"]; n != 1 {
+				t.Errorf("x509_pkcs12_passphrase_failures_total: got %d, want 1", n)
+			}
+			if n := got["x509_jks_passphrase_failures_total"]; n != 1 {
+				t.Errorf("x509_jks_passphrase_failures_total: got %d, want 1", n)
+			}
+			if n := got["x509_kube_transport_errors_total"]; n != tc.wantTransport {
+				t.Errorf("x509_kube_transport_errors_total: got %d series, want %d", n, tc.wantTransport)
+			}
+			if n := got["x509_kube_watch_resyncs_total"]; n != tc.wantResyncs {
+				t.Errorf("x509_kube_watch_resyncs_total: got %d, want %d", n, tc.wantResyncs)
+			}
+
+			// All pre-init'd series must be at value 0 (never incremented).
+			for _, mf := range mfs {
+				if !strings.HasPrefix(*mf.Name, "x509_") {
+					continue
+				}
+				for _, m := range mf.Metric {
+					if m.Counter == nil {
+						continue
+					}
+					if v := m.Counter.GetValue(); v != 0 {
+						t.Errorf("%s: pre-init'd series has value %v, want 0", *mf.Name, v)
+					}
+				}
+			}
+		})
+	}
+}
+
 // TestStatsCacheTracksAllCounters is the regression guard for the
 // `/` stats page: every field of CacheStats is fed by its canonical
 // setter. A future setter that writes directly to the prometheus vec


### PR DESCRIPTION
Five user-facing counters had a UX hit: prometheus.NewCounterVec only materialises a series the first time WithLabelValues(...).Inc() is called, so an exporter running cleanly produced no series at all for x509_source_errors_total, x509_kube_transport_errors_total, x509_cert_collision_dropped_total and the two
x509_{pkcs12,jks}_passphrase_failures_total. Dashboards couldn't tell 'healthy' from 'metric not reporting', rate()/increase() needed two real events to compute anything, and the chart's
SourceErrors[Sustained] / KubeTransportErrors[Sustained] alerts had ambiguous PromQL semantics on first event.

PreInitBundleSource(kind, name) and PreInitKubeTransport(name, resources, namespaceInformer) on Registry materialise the expected series at zero by calling WithLabelValues without .Inc(). The static reason sets they iterate (cert.BundleReasons, cert.KubeTransportPerResourceReasons, cert.ReasonNamespaceSyncFail) live in pkg/cert/reason.go for a single source of truth — dynamic 'http_NNN' reasons are deliberately excluded since they can't be enumerated.

cmd/x509-certificate-exporter/main.go calls the right combination for each config.Source kind right after buildSource: kubernetes sources get both bundle init (kube-secret, kube-configmap) and transport init (per-resource + namespace informer when label rules require it); file/kubeconfig/cabundle sources just get the bundle init for their respective kind. Cardinality cost is bounded by declared reasons × source count — about 50 series per source — and negligible against the per-cert series the exporter produces in normal operation.

TestPreInitMaterializesZeroSeries in pkg/registry locks in the exact series count materialised by a representative call and asserts every emitted counter value is 0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Exporters now pre-initialize and immediately expose metric series at zero on startup, including bundle parsing/collision and Kubernetes transport/watch-resync counters, with appropriate handling for namespace informer-related transport metrics.

* **Tests**
  * Added a regression test that verifies pre-initialized Prometheus counter series are present with correct baseline counts and remain at value `0` before any events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->