### PR TITLE
Fix JCEKS bug vector and improve testing

### DIFF
--- a/cmd/x509-certificate-exporter/main.go
+++ b/cmd/x509-certificate-exporter/main.go
@@ -434,7 +434,7 @@ func buildSource(ctx context.Context, s config.Source, cfg config.Config, ready 
 	case config.KindKubernetes:
 		return buildKubeSource(ctx, s, ready, reg, logger)
 	case config.KindCABundle:
-		return buildCABundleSource(s, ready, logger)
+		return buildCABundleSource(s, ready, reg, logger)
 	}
 	return nil, fmt.Errorf("unknown kind %q", s.Kind)
 }
@@ -717,7 +717,7 @@ func buildKubeSource(ctx context.Context, s config.Source, ready func(bool), reg
 // webhook entry). Shares the kube client construction logic with
 // buildKubeSource; consider extracting if a third K8s-based source is
 // added.
-func buildCABundleSource(s config.Source, ready func(bool), logger *slog.Logger) (cert.Source, error) {
+func buildCABundleSource(s config.Source, ready func(bool), reg *registry.Registry, logger *slog.Logger) (cert.Source, error) {
 	cfg, err := buildKubeClientConfig(s.Kubeconfig, logger)
 	if err != nil {
 		return nil, err
@@ -748,6 +748,7 @@ func buildCABundleSource(s config.Source, ready func(bool), logger *slog.Logger)
 		LabelSelector: buildLabelSelector(cb.IncludeLabels, cb.ExcludeLabels),
 		ExposedLabels: cb.ExposeLabels,
 		OnReady:       ready,
+		Recorder:      reg,
 	}
 	return cabundlesource.New(opts, logger), nil
 }

--- a/dev/scenarios/scenarios_test.go
+++ b/dev/scenarios/scenarios_test.go
@@ -42,19 +42,21 @@ func TestAllParseWithExporter(t *testing.T) {
 					if other, ok := sc.Data[PKCS12PassphraseKey]; ok {
 						pp = string(other)
 					}
-					tryEmpty := key == "keystore-empty.p12"
-					b = p12P.Parse(blob, ref, cert.ParseOptions{Pkcs12Passphrase: pp, Pkcs12TryEmpty: tryEmpty})
+					// main.go (buildKubeSource) defaults Pkcs12TryEmpty to
+					// true for every secretType with a pkcs12 block unless
+					// the user sets it false; dev/values.yaml never sets it
+					// false. Model that default-true here so the self-test
+					// stays a faithful mirror of runtime wiring rather than
+					// only flipping it on for the -empty fixture (which made
+					// the two diverge silently for the encrypted keys).
+					b = p12P.Parse(blob, ref, cert.ParseOptions{Pkcs12Passphrase: pp, Pkcs12TryEmpty: true})
 				case isJKSKey(key):
 					pp := JKSPassphrase
 					if other, ok := sc.Data[JKSPassphraseKey]; ok {
 						pp = string(other)
 					}
-					// Empty-passphrase fixture: dev/values.yaml routes
-					// `truststore-empty.jks` to a secretType with
-					// tryEmptyPassphrase, mirror that here so the
-					// self-test stays representative of runtime wiring.
-					tryEmpty := key == "truststore-empty.jks"
-					b = jksP.Parse(blob, ref, cert.ParseOptions{JksPassphrase: pp, JksTryEmpty: tryEmpty})
+					// Same default-true mirror as the pkcs12 branch above.
+					b = jksP.Parse(blob, ref, cert.ParseOptions{JksPassphrase: pp, JksTryEmpty: true})
 				case isDERKey(key):
 					b = derP.Parse(blob, ref, cert.ParseOptions{})
 				default:

--- a/pkg/cert/jks/jceks_test.go
+++ b/pkg/cert/jks/jceks_test.go
@@ -86,6 +86,172 @@ func buildJCEKSWithSecretKey(t *testing.T, password string) []byte {
 	return buf.Bytes()
 }
 
+// jceksMAC appends the trailing SHA-1 HMAC for a hand-built JCEKS
+// payload. Factored out so malformed payloads (wrong version,
+// oversized lengths) can still carry a *valid* digest and therefore
+// exercise the post-HMAC parsing paths instead of dying at the digest
+// check — which is exactly the attacker model the bounds guards defend
+// against (forged keystore + tryEmptyPassphrase makes the HMAC pass).
+func jceksMAC(password string, payload []byte) []byte {
+	h := sha1.New()
+	for _, b := range []byte(password) {
+		h.Write([]byte{0x00, b})
+	}
+	h.Write([]byte("Mighty Aphrodite"))
+	h.Write(payload)
+	return append(payload, h.Sum(nil)...)
+}
+
+// buildJCEKSKeyStore writes a JCEKS keystore with one PrivateKeyEntry
+// (type=1): a length-prefixed opaque key blob followed by a cert chain.
+// The decoder must skip the key bytes (no decryption) and emit the
+// chain with leaf/intermediate roles.
+func buildJCEKSKeyStore(t *testing.T, password string, keyBlob []byte, chain ...*x509.Certificate) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	put := func(v interface{}) {
+		if err := binary.Write(&buf, binary.BigEndian, v); err != nil {
+			t.Fatal(err)
+		}
+	}
+	putUTF := func(s string) {
+		put(uint16(len(s)))
+		buf.WriteString(s)
+	}
+	put(uint32(0xCECECECE))
+	put(uint32(2))
+	put(uint32(1)) // one entry
+	put(uint32(1)) // PrivateKeyEntry
+	putUTF("key-1")
+	put(time.Now().UnixMilli())
+	put(uint32(len(keyBlob)))
+	buf.Write(keyBlob)
+	put(uint32(len(chain)))
+	for _, c := range chain {
+		putUTF("X.509")
+		put(uint32(len(c.Raw)))
+		buf.Write(c.Raw)
+	}
+	return jceksMAC(password, buf.Bytes())
+}
+
+func TestParseJCEKSKeyStoreChain(t *testing.T) {
+	leaf, _, _ := makeCert(t, "JCEKS Leaf", false)
+	inter, _, _ := makeCert(t, "JCEKS Inter", true)
+	// The key blob is opaque to the decoder — it must skip exactly
+	// len(keyBlob) bytes and never attempt to decode it.
+	data := buildJCEKSKeyStore(t, "changeit", []byte("opaque-encrypted-private-key"), leaf, inter)
+
+	b := New().Parse(data, cert.SourceRef{Kind: "file"}, cert.ParseOptions{JksPassphrase: "changeit"})
+	if len(b.Errors) != 0 {
+		t.Fatalf("unexpected errors: %v", b.Errors)
+	}
+	if len(b.Items) != 2 {
+		t.Fatalf("want 2 chain items, got %d", len(b.Items))
+	}
+	if b.Items[0].Role != cert.RoleLeaf {
+		t.Errorf("item 0 role = %s, want leaf", b.Items[0].Role)
+	}
+	if b.Items[1].Role != cert.RoleIntermediate {
+		t.Errorf("item 1 role = %s, want intermediate", b.Items[1].Role)
+	}
+	if got := b.Items[0].Cert.Subject.CommonName; got != "JCEKS Leaf" {
+		t.Errorf("leaf CN = %q", got)
+	}
+}
+
+func TestParseJCEKSOversizedCertLenRejected(t *testing.T) {
+	// A truststore entry that claims a 4 GiB cert body. The HMAC is
+	// recomputed over the malformed payload so the decoder reaches the
+	// length read; without the remaining-bytes bound this would
+	// make([]byte, ~4e9) and OOM the process. We assert a graceful
+	// fatal error instead.
+	var buf bytes.Buffer
+	put := func(v interface{}) {
+		if err := binary.Write(&buf, binary.BigEndian, v); err != nil {
+			t.Fatal(err)
+		}
+	}
+	putUTF := func(s string) {
+		put(uint16(len(s)))
+		buf.WriteString(s)
+	}
+	put(uint32(0xCECECECE))
+	put(uint32(2))
+	put(uint32(1))
+	put(uint32(2)) // TrustedCertificateEntry
+	putUTF("ca")
+	put(time.Now().UnixMilli())
+	putUTF("X.509")
+	put(uint32(0xFFFFFFF0)) // ~4 GiB cert length, only a few bytes follow
+	buf.Write([]byte{0x01, 0x02, 0x03})
+	data := jceksMAC("changeit", buf.Bytes())
+
+	b := New().Parse(data, cert.SourceRef{Kind: "file"}, cert.ParseOptions{JksPassphrase: "changeit"})
+	if !b.HasFatalError() {
+		t.Fatalf("oversized cert length must produce a fatal error, not OOM")
+	}
+	if got := b.Errors[0].Reason; got != cert.ReasonBadJKS {
+		t.Fatalf("reason = %q, want bad_jks", got)
+	}
+}
+
+func TestParseJCEKSOversizedKeyLenRejected(t *testing.T) {
+	// PrivateKeyEntry that claims a key blob larger than the remaining
+	// payload. bytes.Reader.Seek would silently move past EOF; the
+	// bounded skip must reject it up front.
+	var buf bytes.Buffer
+	put := func(v interface{}) {
+		if err := binary.Write(&buf, binary.BigEndian, v); err != nil {
+			t.Fatal(err)
+		}
+	}
+	putUTF := func(s string) {
+		put(uint16(len(s)))
+		buf.WriteString(s)
+	}
+	put(uint32(0xCECECECE))
+	put(uint32(2))
+	put(uint32(1))
+	put(uint32(1)) // PrivateKeyEntry
+	putUTF("key-1")
+	put(time.Now().UnixMilli())
+	put(uint32(0xFFFFFFF0)) // key length far past EOF
+	buf.Write([]byte{0x01, 0x02})
+	data := jceksMAC("changeit", buf.Bytes())
+
+	b := New().Parse(data, cert.SourceRef{Kind: "file"}, cert.ParseOptions{JksPassphrase: "changeit"})
+	if !b.HasFatalError() {
+		t.Fatalf("oversized key length must produce a fatal error")
+	}
+	if got := b.Errors[0].Reason; got != cert.ReasonBadJKS {
+		t.Fatalf("reason = %q, want bad_jks", got)
+	}
+}
+
+func TestParseJCEKSUnsupportedVersionRejected(t *testing.T) {
+	// Version != 2, HMAC recomputed so the version check (not the
+	// digest check) is what rejects the store.
+	var buf bytes.Buffer
+	put := func(v interface{}) {
+		if err := binary.Write(&buf, binary.BigEndian, v); err != nil {
+			t.Fatal(err)
+		}
+	}
+	put(uint32(0xCECECECE))
+	put(uint32(99)) // unsupported version
+	put(uint32(0))  // zero entries
+	data := jceksMAC("changeit", buf.Bytes())
+
+	b := New().Parse(data, cert.SourceRef{Kind: "file"}, cert.ParseOptions{JksPassphrase: "changeit"})
+	if !b.HasFatalError() {
+		t.Fatalf("unsupported version must produce a fatal error")
+	}
+	if got := b.Errors[0].Reason; got != cert.ReasonBadJKS {
+		t.Fatalf("reason = %q, want bad_jks", got)
+	}
+}
+
 func TestParseJCEKSTrustStore(t *testing.T) {
 	ca1, _, _ := makeCert(t, "JCEKS Trust One", true)
 	ca2, _, _ := makeCert(t, "JCEKS Trust Two", true)

--- a/pkg/cert/jks/jks.go
+++ b/pkg/cert/jks/jks.go
@@ -249,7 +249,14 @@ func decodeJCEKS(data []byte, pass string) ([]itemWithRole, error) {
 		return nil, fmt.Errorf("unsupported JCEKS version %d", version)
 	}
 
+	// Bounded skip: bytes.Reader.Seek silently allows seeking past EOF,
+	// so an attacker-controlled keyLen would move the cursor out of
+	// range and only surface as a misleading error on the *next* read.
+	// Reject oversized lengths up front against the unread remainder.
 	skip := func(n uint32) error {
+		if int64(n) > int64(r.Len()) {
+			return io.ErrUnexpectedEOF
+		}
 		_, err := r.Seek(int64(n), io.SeekCurrent)
 		return err
 	}
@@ -318,6 +325,14 @@ func readJCEKSCert(r *bytes.Reader) (*x509.Certificate, error) {
 	var certLen uint32
 	if err := binary.Read(r, binary.BigEndian, &certLen); err != nil {
 		return nil, fmt.Errorf("cert length: %w", err)
+	}
+	// Bound the allocation against the unread remainder: certLen is an
+	// attacker-controlled uint32 (up to 4 GiB) and reaches this point
+	// once the HMAC passes, which a forged keystore + tryEmptyPassphrase
+	// satisfies. Without this guard, make([]byte, certLen) is a memory
+	// DoS. The cert body cannot exceed the bytes left in the payload.
+	if int64(certLen) > int64(r.Len()) {
+		return nil, fmt.Errorf("cert length %d exceeds %d remaining bytes", certLen, r.Len())
 	}
 	der := make([]byte, certLen)
 	if _, err := io.ReadFull(r, der); err != nil {

--- a/pkg/cert/jks/jks_fuzz_test.go
+++ b/pkg/cert/jks/jks_fuzz_test.go
@@ -48,6 +48,38 @@ func makeJCEKSTrustStoreForFuzz(ca *x509.Certificate, password string) []byte {
 	return buf.Bytes()
 }
 
+// makeJCEKSKeyStoreForFuzz builds a JCEKS keystore carrying a
+// PrivateKeyEntry (opaque key blob + cert chain). Seeds the corpus into
+// the entry-walker branch the truststore seed never reaches — the key
+// skip + per-chain-cert read where the length-bounds guards live.
+func makeJCEKSKeyStoreForFuzz(leaf *x509.Certificate, password string) []byte {
+	var buf bytes.Buffer
+	put := func(v interface{}) { _ = binary.Write(&buf, binary.BigEndian, v) }
+	putUTF := func(s string) { put(uint16(len(s))); buf.WriteString(s) }
+
+	put(uint32(0xCECECECE))
+	put(uint32(2))
+	put(uint32(1))
+	put(uint32(1)) // PrivateKeyEntry
+	putUTF("key-seed")
+	put(time.Now().UnixMilli())
+	put(uint32(8)) // opaque key blob
+	buf.Write([]byte("keyblob0"))
+	put(uint32(1)) // one-cert chain
+	putUTF("X.509")
+	put(uint32(len(leaf.Raw)))
+	buf.Write(leaf.Raw)
+
+	h := sha1.New()
+	for _, b := range []byte(password) {
+		h.Write([]byte{0x00, b})
+	}
+	h.Write([]byte("Mighty Aphrodite"))
+	h.Write(buf.Bytes())
+	buf.Write(h.Sum(nil))
+	return buf.Bytes()
+}
+
 func makeCertForFuzz() (*x509.Certificate, []byte, *ecdsa.PrivateKey) {
 	key, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	tpl := &x509.Certificate{
@@ -80,6 +112,7 @@ func FuzzParse(f *testing.F) {
 	_ = ks.Store(&buf, []byte("seed-pw"))
 	validJKS := buf.Bytes()
 	validJCEKS := makeJCEKSTrustStoreForFuzz(ca, "seed-pw")
+	validJCEKSKeyStore := makeJCEKSKeyStoreForFuzz(ca, "seed-pw")
 
 	magicJKSBytes := make([]byte, 4)
 	binary.BigEndian.PutUint32(magicJKSBytes, magicJKS)
@@ -98,6 +131,8 @@ func FuzzParse(f *testing.F) {
 		validJCEKS,                                // valid JCEKS truststore
 		validJCEKS[:len(validJCEKS)/2],            // truncated JCEKS
 		validJCEKS[:len(validJCEKS)-1],            // JCEKS with corrupted trailing HMAC
+		validJCEKSKeyStore,                        // valid JCEKS keystore (PrivateKeyEntry)
+		validJCEKSKeyStore[:len(validJCEKSKeyStore)/2], // truncated JCEKS keystore
 		[]byte("-----BEGIN CERTIFICATE-----\n"),   // misrouted PEM
 	} {
 		f.Add(seed)

--- a/pkg/cert/jks/jks_test.go
+++ b/pkg/cert/jks/jks_test.go
@@ -107,6 +107,38 @@ func TestParseTrustStore(t *testing.T) {
 	}
 }
 
+func TestParseTrustStoreAliasOrderDeterministic(t *testing.T) {
+	// keystore-go's Aliases() walks an internal map, which Go iterates
+	// in randomized order. The parser sorts aliases before emitting so
+	// item order (and therefore Prometheus series ordering) is stable
+	// across exporter restarts. Build a store whose sorted-alias order
+	// is known (buildTrustStoreJKS assigns trust-a, trust-b, … in cert
+	// order) and assert every parse yields that exact CN sequence.
+	cas := make([]*x509.Certificate, 6)
+	wantCN := make([]string, 6)
+	for i := range cas {
+		cn := "Anchor-" + string(rune('A'+i))
+		c, _, _ := makeCert(t, cn, true)
+		cas[i] = c
+		wantCN[i] = cn
+	}
+	data := buildTrustStoreJKS(t, "changeit", cas...)
+
+	// Many iterations: a map-order regression would surface as a
+	// flaky mismatch on at least one of them.
+	for iter := 0; iter < 20; iter++ {
+		b := New().Parse(data, cert.SourceRef{Kind: "file"}, cert.ParseOptions{JksPassphrase: "changeit"})
+		if len(b.Items) != len(wantCN) {
+			t.Fatalf("iter %d: want %d items, got %d", iter, len(wantCN), len(b.Items))
+		}
+		for i, want := range wantCN {
+			if got := b.Items[i].Cert.Subject.CommonName; got != want {
+				t.Fatalf("iter %d: item %d CN = %q, want %q (alias order not deterministic)", iter, i, got, want)
+			}
+		}
+	}
+}
+
 func TestParseKeyStoreChain(t *testing.T) {
 	leaf, _, leafKey := makeCert(t, "leaf.example.test", false)
 	inter, _, _ := makeCert(t, "intermediate", true)

--- a/pkg/cert/pem/pem_fuzz_test.go
+++ b/pkg/cert/pem/pem_fuzz_test.go
@@ -19,6 +19,10 @@ func FuzzParse(f *testing.F) {
 		[]byte("-----BEGIN CERTIFICATE-----\n-----END CERTIFICATE-----\n"),
 		[]byte("-----BEGIN TRUSTED CERTIFICATE-----\nQUFB\n-----END TRUSTED CERTIFICATE-----\n"),
 		[]byte("-----BEGIN PRIVATE KEY-----\nQUFB\n-----END PRIVATE KEY-----\n"),
+		// CRL blocks — the new RevocationItems path. Without a seed the
+		// fuzzer never mutates towards the X509 CRL branch.
+		[]byte("-----BEGIN X509 CRL-----\nQUFB\n-----END X509 CRL-----\n"),
+		[]byte("-----BEGIN X509 CRL-----\n-----END X509 CRL-----\n"),
 	} {
 		f.Add(seed)
 	}

--- a/pkg/registry/registry_test.go
+++ b/pkg/registry/registry_test.go
@@ -307,7 +307,8 @@ func TestCollisionNeverDedups(t *testing.T) {
 	if err := reg.Register(r); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := reg.Gather(); err != nil {
+	mfs, err := reg.Gather()
+	if err != nil {
 		t.Fatal(err)
 	}
 	if got := testutil.ToFloat64(r.collisionTotal.WithLabelValues("file")); got < 1 {
@@ -318,6 +319,61 @@ func TestCollisionNeverDedups(t *testing.T) {
 	// "silently lost certificate".
 	if got := testutil.ToFloat64(r.collisionDropped.WithLabelValues("file")); got < 1 {
 		t.Fatalf("collisionDropped = %v want >=1 (Never drops the loser)", got)
+	}
+	// Survivor identity: the registry keeps the earliest-expiring cert
+	// (pessimistic — alert on the one that dies soonest). Exactly one
+	// x509_cert_not_after series must remain, equal to c2's NotAfter.
+	var notAfter []float64
+	for _, mf := range mfs {
+		if mf.GetName() != "x509_cert_not_after" {
+			continue
+		}
+		for _, m := range mf.Metric {
+			notAfter = append(notAfter, m.Gauge.GetValue())
+		}
+	}
+	if len(notAfter) != 1 {
+		t.Fatalf("want exactly 1 surviving x509_cert_not_after series, got %d", len(notAfter))
+	}
+	if want := float64(c2.NotAfter.Unix()); notAfter[0] != want {
+		t.Fatalf("survivor not_after = %v, want %v (earliest-expiring c2)", notAfter[0], want)
+	}
+}
+
+// TestCRLMetricsGatedOff verifies the gated CRL series are absent when
+// their feature flags are off: x509_crl_stale needs ExposeExpired,
+// x509_crl_stale_in_seconds / x509_crl_fresh_since_seconds need
+// ExposeRelative. The always-on series (next_update, this_update,
+// number) must still appear. Guards against a Desc-wiring mistake that
+// would leak gated metrics regardless of config.
+func TestCRLMetricsGatedOff(t *testing.T) {
+	r := New(Config{ExposeExpired: false, ExposeRelative: false}, nopLogger())
+	crl := mkCRL(t, "ca", 3, time.Now().Add(24*time.Hour))
+	r.Upsert(cert.Bundle{
+		Source:          cert.SourceRef{Kind: "file", Location: "/etc/x.crl", Format: "pem", SourceName: "files"},
+		RevocationItems: []cert.RevocationItem{{Index: 0, CRL: crl}},
+	})
+	reg := prometheus.NewRegistry()
+	if err := reg.Register(r); err != nil {
+		t.Fatal(err)
+	}
+	mfs, err := reg.Gather()
+	if err != nil {
+		t.Fatal(err)
+	}
+	present := map[string]bool{}
+	for _, mf := range mfs {
+		present[mf.GetName()] = true
+	}
+	for _, gated := range []string{"x509_crl_stale", "x509_crl_stale_in_seconds", "x509_crl_fresh_since_seconds"} {
+		if present[gated] {
+			t.Errorf("%s must be absent when its feature flag is off", gated)
+		}
+	}
+	for _, always := range []string{"x509_crl_next_update", "x509_crl_this_update", "x509_crl_number"} {
+		if !present[always] {
+			t.Errorf("%s must be emitted regardless of feature flags", always)
+		}
 	}
 }
 

--- a/pkg/registry/registry_test.go
+++ b/pkg/registry/registry_test.go
@@ -621,6 +621,61 @@ func TestPkcs12FailuresGatedOff(t *testing.T) {
 	}
 }
 
+func TestJksFailuresGatedOff(t *testing.T) {
+	// Twin of TestPkcs12FailuresGatedOff: a JKS bad-passphrase bundle
+	// with JksInUse=false must not allocate the per-format counter, and
+	// the generic source_errors_total still records it. Guards the nil
+	// branch the format-aware routing relies on.
+	r := New(Config{}, nopLogger())
+	r.Upsert(cert.Bundle{
+		Source: cert.SourceRef{Kind: "file", Location: "/x.jks", SourceName: "files", Format: cert.FormatJKS},
+		Errors: []cert.ItemError{
+			{Index: -1, Reason: cert.ReasonBadPassphrase, Err: errors.New("nope")},
+		},
+	})
+	if r.jksPassphraseFailures != nil {
+		t.Fatalf("jksPassphraseFailures should be nil when JksInUse=false")
+	}
+	if got := testutil.ToFloat64(r.sourceErrors.WithLabelValues("file", "files", "bad_passphrase")); got != 1 {
+		t.Errorf("source_errors_total{reason=bad_passphrase} = %v want 1", got)
+	}
+}
+
+func TestPreInitIsIdempotent(t *testing.T) {
+	// Pre-init runs once per source at startup, but a future resync or
+	// re-registration path could call it twice. WithLabelValues is
+	// idempotent (returns the existing series), so a double call must
+	// not duplicate series nor reset counts.
+	r := New(Config{}, nopLogger())
+	r.PreInitBundleSource(cert.KindKubeSecret, "kube")
+	r.PreInitKubeTransport("kube", []string{"secrets"}, false)
+	// Bump one series, then pre-init again.
+	r.MarkTransportError("kube", "secrets", cert.ReasonWatchFlapped)
+	r.PreInitBundleSource(cert.KindKubeSecret, "kube")
+	r.PreInitKubeTransport("kube", []string{"secrets"}, false)
+
+	reg := prometheus.NewRegistry()
+	if err := reg.Register(r); err != nil {
+		t.Fatal(err)
+	}
+	mfs, err := reg.Gather()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, mf := range mfs {
+		if mf.GetName() != "x509_kube_transport_errors_total" {
+			continue
+		}
+		if n := len(mf.Metric); n != len(cert.KubeTransportPerResourceReasons) {
+			t.Fatalf("transport series count = %d after double pre-init, want %d (no duplication)", n, len(cert.KubeTransportPerResourceReasons))
+		}
+	}
+	// The bumped count must survive the second pre-init.
+	if got := testutil.ToFloat64(r.transportErrors.WithLabelValues("kube", "secrets", "watch_flapped")); got != 1 {
+		t.Fatalf("watch_flapped = %v after re-pre-init, want 1 (not reset)", got)
+	}
+}
+
 // TestExpiredAndNotBeforeGatedOff verifies the new defaults: with
 // neither ExposeNotBefore nor ExposeExpired set, neither
 // `x509_cert_not_before` nor `x509_cert_expired` shows up in

--- a/pkg/source/cabundle/cabundle.go
+++ b/pkg/source/cabundle/cabundle.go
@@ -101,6 +101,19 @@ type Options struct {
 	// OnReady is invoked once after the initial informer sync — true
 	// on success, false if sync was cancelled or hit a fatal error.
 	OnReady func(bool)
+	// Recorder receives transport-level error events from the informers'
+	// reflectors (list/watch failures, reconnect storms). Nil keeps the
+	// log-only behaviour. Mirrors the kubernetes Source's Recorder so
+	// both sources feed x509_kube_transport_errors_total identically.
+	Recorder Recorder
+}
+
+// Recorder is the subset of the registry API the cabundle source uses
+// to emit transport-level operational metrics. Local interface so the
+// source stays decoupled from *registry.Registry and tests can plug a
+// fake. Nil is valid — every call no-ops.
+type Recorder interface {
+	MarkTransportError(sourceName, resource, reason string)
 }
 
 // DefaultResyncEvery is the fallback for Options.ResyncEvery.
@@ -157,6 +170,22 @@ func New(opts Options, logger *slog.Logger) *Source {
 // label on per-source observability metrics).
 func (s *Source) Name() string { return s.opts.Name }
 
+// watchErrHandler returns a reflector WatchErrorHandler that records a
+// transport error against the given resource kind and logs it. Without
+// it, a SharedInformer reflector that loses its watch and can't
+// reconnect (RBAC revoked mid-run, apiserver unreachable) retries
+// silently — invisible in metrics, unlike the kubernetes Source which
+// surfaces the same condition via x509_kube_transport_errors_total.
+// SetWatchErrorHandler must be installed before the informer starts.
+func (s *Source) watchErrHandler(resource string) func(*cache.Reflector, error) {
+	return func(_ *cache.Reflector, err error) {
+		s.log.Debug("cabundle informer watch error", "resource", resource, "err", err)
+		if s.opts.Recorder != nil {
+			s.opts.Recorder.MarkTransportError(s.opts.Name, resource, cert.ReasonWatchErrorEvent)
+		}
+	}
+}
+
 // Run wires up the configured informers and blocks until ctx is
 // cancelled. Returns nil on clean shutdown.
 func (s *Source) Run(ctx context.Context, sink cert.Sink) error {
@@ -194,6 +223,7 @@ func (s *Source) Run(ctx context.Context, sink cert.Sink) error {
 				UpdateFunc: func(_, obj any) { s.onMWC(sink, obj, false) },
 				DeleteFunc: func(obj any) { s.onMWC(sink, obj, true) },
 			})
+			_ = inf.SetWatchErrorHandler(s.watchErrHandler(kindMutating))
 			infs = append(infs, inf)
 		}
 		if s.opts.Resources.Validating {
@@ -203,6 +233,7 @@ func (s *Source) Run(ctx context.Context, sink cert.Sink) error {
 				UpdateFunc: func(_, obj any) { s.onVWC(sink, obj, false) },
 				DeleteFunc: func(obj any) { s.onVWC(sink, obj, true) },
 			})
+			_ = inf.SetWatchErrorHandler(s.watchErrHandler(kindValidating))
 			infs = append(infs, inf)
 		}
 		starters = append(starters, factory.Start)
@@ -217,6 +248,7 @@ func (s *Source) Run(ctx context.Context, sink cert.Sink) error {
 			UpdateFunc: func(_, obj any) { s.onAPIService(sink, obj, false) },
 			DeleteFunc: func(obj any) { s.onAPIService(sink, obj, true) },
 		})
+		_ = inf.SetWatchErrorHandler(s.watchErrHandler(kindAPIService))
 		infs = append(infs, inf)
 		starters = append(starters, factory.Start)
 	}
@@ -230,6 +262,7 @@ func (s *Source) Run(ctx context.Context, sink cert.Sink) error {
 			UpdateFunc: func(_, obj any) { s.onCRD(sink, obj, false) },
 			DeleteFunc: func(obj any) { s.onCRD(sink, obj, true) },
 		})
+		_ = inf.SetWatchErrorHandler(s.watchErrHandler(kindCRD))
 		infs = append(infs, inf)
 		starters = append(starters, factory.Start)
 	}

--- a/pkg/source/cabundle/cabundle_test.go
+++ b/pkg/source/cabundle/cabundle_test.go
@@ -575,3 +575,82 @@ func TestCRDWithoutConversionSkipped(t *testing.T) {
 		t.Fatalf("want no upserts (strategy=None), got %d", len(sink.upsert))
 	}
 }
+
+func TestMalformedCABundleEmitsBundleError(t *testing.T) {
+	// A non-empty caBundle that isn't valid PEM/DER must still produce a
+	// Bundle (so the ref is tracked and observable), carrying a fatal
+	// parse error rather than being silently dropped or panicking. The
+	// input is a CERTIFICATE block with garbage base64, which the PEM
+	// parser rejects as bad_pem.
+	garbage := []byte("-----BEGIN CERTIFICATE-----\nQUFB\n-----END CERTIFICATE-----\n")
+	mwc := &admissionv1.MutatingWebhookConfiguration{
+		ObjectMeta: metav1.ObjectMeta{Name: "broken-webhook"},
+		Webhooks: []admissionv1.MutatingWebhook{
+			{Name: "broken.example", ClientConfig: admissionv1.WebhookClientConfig{CABundle: garbage}},
+		},
+	}
+	src := New(Options{
+		Name:        "cabundles",
+		Client:      fake.NewSimpleClientset(mwc),
+		Resources:   Resources{Mutating: true},
+		ResyncEvery: 10 * time.Minute,
+	}, nopLogger())
+	sink := &fakeSink{}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() { _ = src.Run(ctx, sink) }()
+
+	waitFor(t, func() bool {
+		sink.mu.Lock()
+		defer sink.mu.Unlock()
+		return len(sink.upsert) >= 1
+	}, "malformed caBundle upsert")
+
+	sink.mu.Lock()
+	defer sink.mu.Unlock()
+	b := sink.upsert[0]
+	// A single garbage cert is a per-item error (Index >= 0), not a
+	// bundle-level fatal — the contract is that it surfaces as an error
+	// the registry counts, never a silent drop or a panic.
+	if len(b.Errors) == 0 {
+		t.Fatalf("malformed caBundle must surface a bundle error, got %+v", b)
+	}
+	if got := b.Errors[0].Reason; got != cert.ReasonBadPEM {
+		t.Fatalf("reason = %q, want bad_pem", got)
+	}
+	if len(b.Items) != 0 {
+		t.Fatalf("malformed caBundle must not yield items, got %d", len(b.Items))
+	}
+}
+
+type recordingRecorder struct {
+	mu    sync.Mutex
+	calls [][3]string // source_name, resource, reason
+}
+
+func (r *recordingRecorder) MarkTransportError(sourceName, resource, reason string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.calls = append(r.calls, [3]string{sourceName, resource, reason})
+}
+
+func TestWatchErrHandlerForwardsTransportError(t *testing.T) {
+	rec := &recordingRecorder{}
+	src := New(Options{Name: "cabundles", Recorder: rec}, nopLogger())
+	src.watchErrHandler(kindMutating)(nil, io.ErrUnexpectedEOF)
+
+	rec.mu.Lock()
+	defer rec.mu.Unlock()
+	if len(rec.calls) != 1 {
+		t.Fatalf("want 1 transport-error call, got %d", len(rec.calls))
+	}
+	if rec.calls[0] != [3]string{"cabundles", kindMutating, cert.ReasonWatchErrorEvent} {
+		t.Fatalf("call = %v, want {cabundles, %s, watch_error_event}", rec.calls[0], kindMutating)
+	}
+}
+
+func TestWatchErrHandlerNilRecorderIsSafe(t *testing.T) {
+	// No Recorder configured — the handler must no-op, not panic.
+	src := New(Options{Name: "cabundles"}, nopLogger())
+	src.watchErrHandler(kindAPIService)(nil, io.ErrUnexpectedEOF)
+}

--- a/pkg/source/k8s/k8s_passphrase_test.go
+++ b/pkg/source/k8s/k8s_passphrase_test.go
@@ -3,6 +3,7 @@ package k8s
 import (
 	"context"
 	"regexp"
+	"strings"
 	"sync"
 	"testing"
 
@@ -279,5 +280,197 @@ func TestJksPassphraseSecretRefExplicitNamespace(t *testing.T) {
 
 	if got := parser.lastOpts(t).JksPassphrase; got != "cross-ns-jks" {
 		t.Fatalf("JksPassphrase = %q, want %q", got, "cross-ns-jks")
+	}
+}
+
+// soleUpsert returns the single Bundle a fakeSink received, failing if
+// the count isn't exactly one. The fail-fast tests use it to inspect
+// the bad_passphrase bundle the source emits instead of calling the
+// parser.
+func soleUpsert(t *testing.T, sink *fakeSink) cert.Bundle {
+	t.Helper()
+	sink.mu.Lock()
+	defer sink.mu.Unlock()
+	if len(sink.upsert) != 1 {
+		t.Fatalf("want exactly 1 upsert, got %d", len(sink.upsert))
+	}
+	return sink.upsert[0]
+}
+
+// TestPassphraseFailFastEmitsBadPassphraseBundle pins the output of the
+// skip-parse path: one bundle carrying a bundle-level (Index -1)
+// bad_passphrase error whose Err names the concrete cause. The earlier
+// tests asserted only "parser not called", leaving the emitted metric
+// and its reason invisible to the suite.
+func TestPassphraseFailFastEmitsBadPassphraseBundle(t *testing.T) {
+	certSec := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "tls", Namespace: "ns"},
+		Type:       corev1.SecretType("kubernetes.io/tls"),
+		Data:       map[string][]byte{"keystore.p12": []byte("blob")},
+	}
+	parser := &recordingParser{}
+	rule := SecretTypeRule{
+		Type:          "kubernetes.io/tls",
+		KeyRe:         regexp.MustCompile(`^keystore\.p12$`),
+		PassphraseKey: "missing-key", // not present in the cert Secret
+		Parser:        parser,
+	}
+	src := newSource(t, rule, certSec)
+	sink := &fakeSink{}
+	src.onSecret(context.Background(), sink, certSec, false)
+
+	parser.assertNotCalled(t)
+	b := soleUpsert(t, sink)
+	if len(b.Errors) != 1 {
+		t.Fatalf("want 1 bundle error, got %d (%v)", len(b.Errors), b.Errors)
+	}
+	e := b.Errors[0]
+	if e.Index != -1 {
+		t.Errorf("Index = %d, want -1 (bundle-level)", e.Index)
+	}
+	if e.Reason != cert.ReasonBadPassphrase {
+		t.Errorf("Reason = %q, want bad_passphrase", e.Reason)
+	}
+	if e.Err == nil || !strings.Contains(e.Err.Error(), "missing-key") {
+		t.Errorf("Err = %v, want it to name the missing key", e.Err)
+	}
+}
+
+// TestPassphraseTwoSourcesOneSucceedsStillParses covers the
+// passphraseObtained accumulation: when two passphrase sources are
+// configured and at least one yields a value, the parser must be
+// called — a regression to "fail if any source fails" would skip it.
+func TestPassphraseTwoSourcesOneSucceedsStillParses(t *testing.T) {
+	certSec := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "tls", Namespace: "ns"},
+		Type:       corev1.SecretType("kubernetes.io/tls"),
+		Data: map[string][]byte{
+			"keystore.p12":    []byte("blob"),
+			"inline-pass-key": []byte("from-inline"),
+		},
+	}
+	parser := &recordingParser{}
+	rule := SecretTypeRule{
+		Type:                "kubernetes.io/tls",
+		KeyRe:               regexp.MustCompile(`^keystore\.p12$`),
+		PassphraseKey:       "inline-pass-key",                         // present → succeeds
+		PassphraseSecretRef: &PassphraseSecretRef{Name: "absent", Key: "pp"}, // fails
+		Parser:              parser,
+	}
+	src := newSource(t, rule, certSec)
+	src.onSecret(context.Background(), &fakeSink{}, certSec, false)
+
+	// The inline key won; the failed ref must not have overwritten it.
+	if got := parser.lastOpts(t).Pkcs12Passphrase; got != "from-inline" {
+		t.Fatalf("Pkcs12Passphrase = %q, want %q (sticky obtained value)", got, "from-inline")
+	}
+}
+
+// TestPassphraseTwoSourcesBothFailEmitsLastCause verifies that when
+// every configured source fails, the emitted bundle error carries the
+// last failure's cause (the SecretRef lookup here).
+func TestPassphraseTwoSourcesBothFailEmitsLastCause(t *testing.T) {
+	certSec := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "tls", Namespace: "ns"},
+		Type:       corev1.SecretType("kubernetes.io/tls"),
+		Data:       map[string][]byte{"keystore.p12": []byte("blob")},
+	}
+	parser := &recordingParser{}
+	rule := SecretTypeRule{
+		Type:                "kubernetes.io/tls",
+		KeyRe:               regexp.MustCompile(`^keystore\.p12$`),
+		PassphraseKey:       "missing-key",                              // fails first
+		PassphraseSecretRef: &PassphraseSecretRef{Name: "absent", Key: "pp"}, // fails last
+		Parser:              parser,
+	}
+	src := newSource(t, rule, certSec)
+	sink := &fakeSink{}
+	src.onSecret(context.Background(), sink, certSec, false)
+
+	parser.assertNotCalled(t)
+	b := soleUpsert(t, sink)
+	if len(b.Errors) != 1 || b.Errors[0].Err == nil {
+		t.Fatalf("want 1 bundle error with a cause, got %v", b.Errors)
+	}
+	if got := b.Errors[0].Err.Error(); !strings.Contains(got, "absent") {
+		t.Errorf("Err = %q, want last cause (SecretRef lookup of 'absent')", got)
+	}
+}
+
+// TestJksTryEmptyDrivesFailFast pins the format switch in onSecret:
+// for a JKS rule the skip-parse decision must read JksTryEmpty, not
+// Pkcs12TryEmpty. The two cases below would both break if the switch
+// arms were swapped.
+func TestJksTryEmptyDrivesFailFast(t *testing.T) {
+	mkCertSec := func() *corev1.Secret {
+		return &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: "ks", Namespace: "ns"},
+			Type:       corev1.SecretType("Opaque"),
+			Data:       map[string][]byte{"truststore.jks": []byte("blob")},
+		}
+	}
+
+	t.Run("JksTryEmpty=true parses despite missing key", func(t *testing.T) {
+		parser := &recordingParser{format: cert.FormatJKS}
+		rule := SecretTypeRule{
+			Type:             "Opaque",
+			KeyRe:            regexp.MustCompile(`^truststore\.jks$`),
+			JksPassphraseKey: "missing",
+			// Pkcs12TryEmpty deliberately false: if the switch read it
+			// instead of JksTryEmpty, this would wrongly skip the parser.
+			ParseOpts: cert.ParseOptions{JksTryEmpty: true},
+			Parser:    parser,
+		}
+		src := newSource(t, rule, mkCertSec())
+		src.onSecret(context.Background(), &fakeSink{}, mkCertSec(), false)
+		if got := parser.lastOpts(t).JksPassphrase; got != "" {
+			t.Fatalf("JksPassphrase = %q, want empty", got)
+		}
+	})
+
+	t.Run("JksTryEmpty=false skips parse even if Pkcs12TryEmpty=true", func(t *testing.T) {
+		parser := &recordingParser{format: cert.FormatJKS}
+		rule := SecretTypeRule{
+			Type:             "Opaque",
+			KeyRe:            regexp.MustCompile(`^truststore\.jks$`),
+			JksPassphraseKey: "missing",
+			// Trap: Pkcs12TryEmpty true must be ignored for a JKS rule.
+			ParseOpts: cert.ParseOptions{Pkcs12TryEmpty: true, JksTryEmpty: false},
+			Parser:    parser,
+		}
+		src := newSource(t, rule, mkCertSec())
+		sink := &fakeSink{}
+		src.onSecret(context.Background(), sink, mkCertSec(), false)
+		parser.assertNotCalled(t)
+		if b := soleUpsert(t, sink); b.Errors[0].Reason != cert.ReasonBadPassphrase {
+			t.Fatalf("reason = %q, want bad_passphrase", b.Errors[0].Reason)
+		}
+	})
+}
+
+// TestPassphraseKeyTrimsOnlyCRLF verifies the secret-sourced passphrase
+// is trimmed of trailing CR/LF only — interior and significant spaces
+// must survive (a passphrase legitimately containing spaces).
+func TestPassphraseKeyTrimsOnlyCRLF(t *testing.T) {
+	certSec := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "tls", Namespace: "ns"},
+		Type:       corev1.SecretType("kubernetes.io/tls"),
+		Data: map[string][]byte{
+			"keystore.p12": []byte("blob"),
+			"pp":           []byte("  pass with spaces  \r\n"),
+		},
+	}
+	parser := &recordingParser{}
+	rule := SecretTypeRule{
+		Type:          "kubernetes.io/tls",
+		KeyRe:         regexp.MustCompile(`^keystore\.p12$`),
+		PassphraseKey: "pp",
+		Parser:        parser,
+	}
+	src := newSource(t, rule, certSec)
+	src.onSecret(context.Background(), &fakeSink{}, certSec, false)
+
+	if got := parser.lastOpts(t).Pkcs12Passphrase; got != "  pass with spaces  " {
+		t.Fatalf("Pkcs12Passphrase = %q, want CR/LF trimmed but spaces kept", got)
 	}
 }

--- a/test/render/prometheusrules-disable-without-extras.expect.txt
+++ b/test/render/prometheusrules-disable-without-extras.expect.txt
@@ -1,0 +1,1 @@
+Extra alert groups (extraAlertGroups) are required when disableBuiltinAlertGroup is set

--- a/test/render/prometheusrules-disable-without-extras.yaml
+++ b/test/render/prometheusrules-disable-without-extras.yaml
@@ -1,0 +1,8 @@
+# disableBuiltinAlertGroup drops the shipped alert group, so the user
+# MUST supply extraAlertGroups — otherwise the PrometheusRule would
+# render with an empty `groups:` list, which the prometheus-operator
+# rejects. The chart fails fast at render time instead.
+prometheusRules:
+  create: true
+  disableBuiltinAlertGroup: true
+  extraAlertGroups: []

--- a/test/render/prometheusrules-overrides.expect-pass.txt
+++ b/test/render/prometheusrules-overrides.expect-pass.txt
@@ -1,0 +1,12 @@
+# Substrings matched verbatim against `helm template` stdout (the test
+# strips comments + blank lines, takes the rest as-is). expr/for are
+# mapping keys, not list items, so no leading "- ".
+#
+# The override expr must reach the rendered rule verbatim (proves the
+# `get $exprOverrides` lookup fires, not a silent fallback to default).
+expr: "max by (cluster) (x509_cert_not_after - time()) < (21 * 86400)"
+# The override `for:` duration must reach the rendered rule.
+for: 1h30m
+# rulePrefix prepends with a single space (printf "%s %s" | trim).
+- alert: 'MyTeam CertificateRenewal'
+- alert: 'MyTeam KubeTransportErrorsSustained'

--- a/test/render/prometheusrules-overrides.yaml
+++ b/test/render/prometheusrules-overrides.yaml
@@ -1,0 +1,13 @@
+# Exercises the per-alert override maps AND rulePrefix at render time.
+# The default-alerts ratchet only matches alert names, so a template
+# typo in the override `get` lookup would silently fall back to the
+# default expr and go unnoticed. This fixture pins that an override
+# actually reaches the rendered output, and that rulePrefix prepends to
+# the alert name with a single space.
+prometheusRules:
+  create: true
+  rulePrefix: "MyTeam"
+  alertExprOverrides:
+    CertificateRenewal: "max by (cluster) (x509_cert_not_after - time()) < (21 * 86400)"
+  alertForOverrides:
+    KubeTransportErrorsSustained: "1h30m"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Hardened JKS/JCEKS parsing by validating declared certificate/key lengths and failing safely when values exceed available data.
  * Improved CABundle handling by recording informer watch/list transport errors and surfacing malformed CA bundles as bundle item errors.
* **New Features**
  * CABundle discovery can now record transport error metrics into the shared Prometheus registry.
  * Prometheus alert rules support rule prefixing and per-alert expression/duration overrides.
* **Tests**
  * Added/expanded unit, fuzz, and rendering coverage for parsing validation, deterministic truststore ordering, metric gating/idempotency, and additional CRL-related PEM seeds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->