### PR TITLE
ci(security): scan secrets via gitleaks CLI in Dagger, not gitleaks-action

### DIFF
--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -18,6 +18,10 @@ env:
   DAGGER_CLOUD_TOKEN: ""
   DO_NOT_TRACK: "1"
 
+# Every job here only checks out + scans; none push or need git write
+# access, so each checkout sets `persist-credentials: false` to keep the
+# GITHUB_TOKEN out of the workspace's .git/config (zizmor "artipacked").
+
 jobs:
   changes:
     name: Detect changed paths
@@ -29,6 +33,8 @@ jobs:
       chart: ${{ steps.filter.outputs.chart }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
       - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4
         id: filter
         with:
@@ -54,6 +60,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          # gitleaks scans the working tree, not git history — shallow.
+          fetch-depth: 1
+          persist-credentials: false
       - uses: dagger/dagger-for-github@27b130bf0f79a7f6fbbbe0fbca6760dc9bb40a77 # v8
         with:
           version: latest
@@ -76,6 +86,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 1
+          persist-credentials: false
       - uses: dagger/dagger-for-github@27b130bf0f79a7f6fbbbe0fbca6760dc9bb40a77 # v8
         with:
           version: latest
@@ -96,6 +107,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
       - uses: dagger/dagger-for-github@27b130bf0f79a7f6fbbbe0fbca6760dc9bb40a77 # v8
         with:
           version: latest
@@ -113,6 +126,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
       - uses: dagger/dagger-for-github@27b130bf0f79a7f6fbbbe0fbca6760dc9bb40a77 # v8
         with:
           version: latest

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -46,25 +46,20 @@ jobs:
               - 'chart/**'
               - 'dagger/**'
 
-  # Secret leak detection on the full diff. Always runs — any file can leak.
+  # Secret leak detection. Always runs — any file can leak. Routed
+  # through the Dagger Module's `Gitleaks` function (see CLAUDE.md for
+  # why this isn't gitleaks-action).
   secrets:
     name: Secret leaks (Gitleaks)
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: write # gitleaks-action posts the leaks summary as a PR comment
-
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: dagger/dagger-for-github@27b130bf0f79a7f6fbbbe0fbca6760dc9bb40a77 # v8
         with:
-          fetch-depth: 0 # gitleaks needs history to walk the diff
-      - uses: gitleaks/gitleaks-action@e0c47f4f8be36e29cdc102c57e68cb5cbf0e8d1e # v3
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # Required for orgs since gitleaks-action v2 (the action is free
-          # for personal accounts but org-scoped repos need a key — see
-          # https://github.com/gitleaks/gitleaks-action#-announcement).
-          GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}
+          version: latest
+          dagger-flags: --progress=logs
+          verb: call
+          args: gitleaks
 
   # Reachability-based vulnerability check for Go code. Routed through
   # the Dagger Module so the govulncheck version + flags stay aligned

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,2 +1,0 @@
-d2fe6a2951a03e93a472135925764c7f4fb941cc:cmd/x509-certificate-exporter/main.go:generic-api-key:351
-9834740662e5cb8caf6ebfc3c438f9b58e12db4d:cmd/x509-certificate-exporter/main.go:generic-api-key:351

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,6 +62,7 @@ everything.
 | Helm schema fixtures | `task test:helm-fixtures` | `dagger call test-helm-fixtures` — regression net for `chart/values.schema.json` (positive + paired `.expect.txt` negatives under `test/schema/{valid,invalid}/`) |
 | Helm render alignment | `task test:helm-render` | `dagger call test-helm-render` — `helm template` against `test/render/all-watch-modes.yaml` and assert every ConfigMap scan path is reachable from a DaemonSet volumeMount (catches configmap↔daemonset drift) |
 | End-to-end tests | `task test:e2e` | throwaway k3d cluster, Helm install, scrape `/metrics` |
+| Secret leak scan | `task security:gitleaks` | `dagger call gitleaks` — open-source gitleaks CLI on the working tree; no license/token, so fork PRs scan identically |
 | Vuln scan | `task security:govulncheck` | `dagger call govulncheck` |
 | Vuln scan (deps) | `task security:vuln-deps` | `dagger call trivy --scan-type=fs` |
 | Chart misconfig | `task security:chart-misconfig` | `dagger call trivy --scan-type=config --scan-ref=chart` |
@@ -101,11 +102,19 @@ Layout:
   Adds `gcc` + `musl-dev` to the alpine container because `-race`
   requires CGO, which on Alpine pulls those.
 - `dagger/security.go` — `Govulncheck` (`@latest` — accepting the
-  small drift in exchange for not having to track a separate version)
-  and `Trivy` (one parameterized function for both scan families:
+  small drift in exchange for not having to track a separate version),
+  `Trivy` (one parameterized function for both scan families:
   `--scan-type=fs` for Go deps + lockfiles + OS packages; `--scan-type=config`
-  with `--scan-ref=chart` for IaC misconfig). Trivy DB cached via a
-  Dagger CacheVolume so successive runs skip the ~50 MB download.
+  with `--scan-ref=chart` for IaC misconfig; Trivy DB cached via a
+  Dagger CacheVolume so successive runs skip the ~50 MB download), and
+  `Gitleaks` (open-source gitleaks CLI, `gitleaks dir` on the tree).
+  Gitleaks runs the binary rather than gitleaks-action because the
+  action needs a paid `GITLEAKS_LICENSE` + a write token to comment,
+  and GitHub withholds both from fork `pull_request` workflows — so the
+  action failed on external PRs. Its `source` param carries its own
+  `+ignore` (drops `dist/`/`node_modules/`/`.git/` but keeps `dagger/`)
+  rather than reusing the module-wide filter, so hand-written code stays
+  in the secret scan.
 - `dagger/helm.go` — `HelmDocs` runs jnorwood/helm-docs and returns a
   `*dagger.File`. The Taskfile chains `... export --path=chart/README.md`
   to materialize it back to the working tree.

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -352,9 +352,15 @@ tasks:
   security:
     desc: Run all security checks
     cmds:
+      - task: security:gitleaks
       - task: security:govulncheck
       - task: security:vuln-deps
       - task: security:chart-misconfig
+
+  security:gitleaks:
+    desc: "Gitleaks — scan the working tree for committed secrets"
+    cmds:
+      - dagger call gitleaks
 
   security:govulncheck:
     desc: govulncheck — reachability-based CVE scan on Go code

--- a/cmd/x509-certificate-exporter/main.go
+++ b/cmd/x509-certificate-exporter/main.go
@@ -94,7 +94,7 @@ func run() error {
 		WatchKubeconf: cli.WatchKubeconfs, WatchKubeSecrets: cli.WatchKubeSecrets,
 		Listen: cli.Listen, WebConfigFile: cli.WebConfigFile,
 		ProbeListen: cli.ProbeListen,
-		Debug: cli.Debug, Profile: cli.Profile,
+		Debug:       cli.Debug, Profile: cli.Profile,
 	})
 	if !config.HasSources(cfg) {
 		return config.ErrNoSources
@@ -575,7 +575,7 @@ func buildKubeSource(ctx context.Context, s config.Source, ready func(bool), reg
 				}
 				if t.Pkcs12 != nil {
 					if t.Pkcs12.PassphraseKey != "" {
-						rule.PassphraseKey = t.Pkcs12.PassphraseKey
+						rule.PassphraseKey = t.Pkcs12.PassphraseKey //gitleaks:allow // field name, not a secret value
 					}
 					if t.Pkcs12.PassphraseSecretRef != nil {
 						rule.PassphraseSecretRef = &k8ssource.PassphraseSecretRef{
@@ -592,7 +592,7 @@ func buildKubeSource(ctx context.Context, s config.Source, ready func(bool), reg
 				}
 				if t.Jks != nil {
 					if t.Jks.PassphraseKey != "" {
-						rule.JksPassphraseKey = t.Jks.PassphraseKey
+						rule.JksPassphraseKey = t.Jks.PassphraseKey //gitleaks:allow // field name, not a secret value
 					}
 					if t.Jks.PassphraseSecretRef != nil {
 						rule.JksPassphraseSecretRef = &k8ssource.PassphraseSecretRef{

--- a/dagger/base.go
+++ b/dagger/base.go
@@ -7,14 +7,15 @@ import (
 // Pinned image versions. Renovate's `regex` manager (configured in
 // renovate.json5) tracks the `<name>Image = "..."` literals here.
 const (
-	golangImage = "golang:1.26.4-alpine@sha256:7a3e50096189ad57c9f9f865e7e4aa8585ed1585248513dc5cda498e2f41812c"
-	alpineImage = "alpine:3.24.0@sha256:a2d49ea686c2adfe3c992e47dc3b5e7fa6e6b5055609400dc2acaeb241c829f4"
-	helmImage = "alpine/helm:4.2.1@sha256:8647f126de3578d74f947ba735e4cfa0ea6aea7d6e2f36bceb86f31415944dca"
-	renovateImage = "renovate/renovate:43.224.0@sha256:917942c6021720b042ef2bfce54455497ac92d24396b7b4b2a97ef6513697bc4"
-	helmDocsImage = "jnorwood/helm-docs:v1.14.2@sha256:7e562b49ab6b1dbc50c3da8f2dd6ffa8a5c6bba327b1c6335cc15ce29267979c"
-	helmSchemaImage = "ghcr.io/dadav/helm-schema:0.23.2@sha256:4807d868cb489e8160e0cece1aba51d2101a9c307b76bdda4f88929c75bd5c29"
+	golangImage       = "golang:1.26.4-alpine@sha256:7a3e50096189ad57c9f9f865e7e4aa8585ed1585248513dc5cda498e2f41812c"
+	alpineImage       = "alpine:3.24.0@sha256:a2d49ea686c2adfe3c992e47dc3b5e7fa6e6b5055609400dc2acaeb241c829f4"
+	helmImage         = "alpine/helm:4.2.1@sha256:8647f126de3578d74f947ba735e4cfa0ea6aea7d6e2f36bceb86f31415944dca"
+	renovateImage     = "renovate/renovate:43.224.0@sha256:917942c6021720b042ef2bfce54455497ac92d24396b7b4b2a97ef6513697bc4"
+	helmDocsImage     = "jnorwood/helm-docs:v1.14.2@sha256:7e562b49ab6b1dbc50c3da8f2dd6ffa8a5c6bba327b1c6335cc15ce29267979c"
+	helmSchemaImage   = "ghcr.io/dadav/helm-schema:0.23.2@sha256:4807d868cb489e8160e0cece1aba51d2101a9c307b76bdda4f88929c75bd5c29"
 	markdownlintImage = "davidanson/markdownlint-cli2:v0.22.1@sha256:0ed9a5f4c77ef447da2a2ac6e67caf74b214a7f80288819565e8b7d2ac148fe5"
-	trivyImage = "aquasec/trivy:0.71.1@sha256:53570e6911c2361ebe7995228088cf83a6b9b73e7f3cdca44bd8f8f425e80fa7"
+	trivyImage        = "aquasec/trivy:0.71.1@sha256:53570e6911c2361ebe7995228088cf83a6b9b73e7f3cdca44bd8f8f425e80fa7"
+	gitleaksImage     = "ghcr.io/gitleaks/gitleaks:v8.30.1@sha256:c00b6bd0aeb3071cbcb79009cb16a60dd9e0a7c60e2be9ab65d25e6bc8abbb7f"
 	golangciLint      = "v2.12.2" // installed via `go install`
 	gotestsumModule   = "v1.13.0" // ditto
 	govulncheckPath   = "latest"  // tracking latest, no Renovate pin

--- a/dagger/security.go
+++ b/dagger/security.go
@@ -3,7 +3,40 @@ package main
 import (
 	"context"
 	"fmt"
+
+	"dagger/x-509-ce/internal/dagger"
 )
+
+// Gitleaks scans the working tree for committed secrets (`gitleaks
+// dir`, not git history: .git is excluded from the source and the
+// delivered file contents are what matter). Exits non-zero on any
+// finding, which Dagger surfaces as an error and CI as a failed job;
+// findings print (redacted) to the log.
+func (m *X509Ce) Gitleaks(
+	ctx context.Context,
+	// Working tree to scan. Drops build artifacts and vendored trees
+	// that would only add scan noise, but — unlike the module-wide
+	// source filter — KEEPS dagger/ so hand-written code stays in scope.
+	// +defaultPath="/"
+	// +ignore=[".git/", "dist/", "node_modules/", "kubeconfig.yaml", "renovate-debug.log"]
+	source *dagger.Directory,
+) (string, error) {
+	return dag.Container().
+		From(gitleaksImage).
+		WithMountedDirectory("/scan", source).
+		// Workdir at the scan root so finding paths/fingerprints are
+		// relative (not /scan/...) and any `.gitleaks.toml` / inline
+		// `//gitleaks:allow` directives in the tree resolve correctly.
+		WithWorkdir("/scan").
+		WithExec([]string{
+			"gitleaks", "dir", ".",
+			"--no-banner",
+			"--redact",
+			"--verbose",
+			"--exit-code", "1",
+		}).
+		Stdout(ctx)
+}
 
 // Govulncheck runs Go's reachability-based CVE scanner. The
 // vulnerability database is fetched from vuln.go.dev at run time —


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `security:gitleaks` secret-scanning step and enabled it in the `security` workflow before other security checks.
* **Chores**
  * Updated secret scanning to run through the existing Dagger pipeline for working-tree scanning.
  * Hardened CI checkouts by disabling persisted Git credentials and adjusted scan checkout depth.
  * Updated pinned scanning image versions and refreshed `.gitleaksignore` rules.
* **Documentation**
  * Expanded security documentation with Gitleaks invocation and behavior details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->