### PR TITLE
feat: add support for SAN (DNS names and IP addresses) #458

### DIFF
--- a/chart/templates/configmap.yaml
+++ b/chart/templates/configmap.yaml
@@ -30,6 +30,7 @@ data:
       exposePerCertError: {{ .Values.exposePerCertificateErrorMetrics | default false }}
       exposeNotBefore: {{ .Values.exposeNotBeforeMetric }}
       exposeExpired: {{ .Values.exposeExpiredMetric }}
+      exposeSAN: {{ .Values.exposeSANMetric }}
       exposeDiagnostics: {{ .Values.exposeDiagnosticMetrics }}
       {{- if not (kindIs "invalid" .Values.metricLabelsFilterList) }}
       exposeSubjectFields: {{ .Values.metricLabelsFilterList | toJson }}
@@ -138,6 +139,7 @@ data:
       exposePerCertError: {{ $.Values.exposePerCertificateErrorMetrics | default false }}
       exposeNotBefore: {{ $.Values.exposeNotBeforeMetric }}
       exposeExpired: {{ $.Values.exposeExpiredMetric }}
+      exposeSAN: {{ $.Values.exposeSANMetric }}
       exposeDiagnostics: {{ $.Values.exposeDiagnosticMetrics }}
       trimPathComponents: 3
       {{- if not (kindIs "invalid" $.Values.metricLabelsFilterList) }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -111,6 +111,9 @@ exposeNotBeforeMetric: false
 # -- Expose `x509_cert_expired` (1 if the certificate is expired, 0 otherwise). On by default ; turn off to halve the per-cert series count if you only alert on `x509_cert_not_after - time()`.
 exposeExpiredMetric: true
 
+# -- Expose `x509_cert_san` (one series per Subject Alternative Name with DNS or IP). Off by default ; enable to track SANs in Prometheus.
+exposeSANMetric: false
+
 # -- Expose self-introspection metrics for debugging the exporter itself (`x509_parse_duration_seconds`, `x509_kube_request_duration_seconds`, `x509_kube_informer_scope`, `x509_informer_queue_depth`). Off by default ; enable when you actually need to look inside.
 exposeDiagnosticMetrics: false
 

--- a/cmd/x509-certificate-exporter/main.go
+++ b/cmd/x509-certificate-exporter/main.go
@@ -144,6 +144,7 @@ func run() error {
 		ExposePerCertError:     cfg.Metrics.ExposePerCertError,
 		ExposeNotBefore:        cfg.Metrics.ExposeNotBefore,
 		ExposeExpired:          cfg.Metrics.ExposeExpired,
+		ExposeSAN:              cfg.Metrics.ExposeSAN,
 		ExposeDiagnostics:      cfg.Metrics.ExposeDiagnostics,
 		Pkcs12InUse:            pkcs12InUse(cfg),
 		JksInUse:               jksInUse(cfg),

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -237,6 +237,10 @@ type Metrics struct {
 	// per-cert series count for users who alert exclusively on
 	// `not_after - time()`.
 	ExposeExpired                bool     `yaml:"exposeExpired"`
+	// ExposeSAN controls the per-cert `x509_cert_san` metric, which
+	// emits one series per Subject Alternative Name (DNS or IP).
+	// Off by default to keep `/metrics` lean.
+	ExposeSAN                    bool     `yaml:"exposeSAN"`
 	// ExposeDiagnostics gates a group of self-introspection metrics
 	// (parse latency, kube API latency, source scope, namespace
 	// informer queue depth) that help debugging the exporter itself

--- a/pkg/registry/collector.go
+++ b/pkg/registry/collector.go
@@ -18,6 +18,7 @@ type descTable struct {
 	notBefore, notAfter, expired *prometheus.Desc
 	expiresIn, validSince        *prometheus.Desc
 	certError                    *prometheus.Desc
+	certSAN                      *prometheus.Desc
 	// CRL family — emitted whenever a Bundle carries RevocationItems.
 	// `stale` mirrors `expired` (gated by ExposeExpired); `staleIn` and
 	// `freshSince` are the relative counterparts gated by ExposeRelative.
@@ -52,6 +53,9 @@ func newDescTable(cfg Config) descTable {
 	if cfg.ExposePerCertError {
 		t.certError = prometheus.NewDesc("x509_cert_error", "1 if the corresponding bundle item failed to parse, 0 otherwise.", s.names, nil)
 	}
+	if cfg.ExposeSAN {
+		t.certSAN = prometheus.NewDesc("x509_cert_san", "Indicates the Subject Alternative Names (DNS or IP) present in the certificate.", append(s.names, "SAN_value", "SAN_type"), nil)
+	}
 	t.crlNextUpdate = prometheus.NewDesc("x509_crl_next_update", "Unix timestamp of the CRL's nextUpdate (RFC 5280 §5.1.2.5).", s.names, nil)
 	t.crlThisUpdate = prometheus.NewDesc("x509_crl_this_update", "Unix timestamp of the CRL's thisUpdate (RFC 5280 §5.1.2.4).", s.names, nil)
 	t.crlNumber = prometheus.NewDesc("x509_crl_number", "Value of the CRL's cRLNumber extension (RFC 5280 §5.2.3); 0 if absent.", s.names, nil)
@@ -81,6 +85,9 @@ func (t descTable) describe(ch chan<- *prometheus.Desc) {
 	}
 	if t.certError != nil {
 		ch <- t.certError
+	}
+	if t.certSAN != nil {
+		ch <- t.certSAN
 	}
 	ch <- t.crlNextUpdate
 	ch <- t.crlThisUpdate
@@ -250,11 +257,16 @@ func (r *Registry) emitItem(ch chan<- prometheus.Metric, ki keyedItem, withDisc 
 			vals[r.descs.schema.idxDiscriminator] = ""
 		}
 	}
-	emit := func(d *prometheus.Desc, v float64) {
+	emit := func(d *prometheus.Desc, v float64, extra ...string) {
 		if d == nil {
 			return
 		}
-		ch <- prometheus.MustNewConstMetric(d, prometheus.GaugeValue, v, vals...)
+		labelVals := vals
+		if len(extra) > 0 {
+			labelVals = append([]string{}, vals...)
+			labelVals = append(labelVals, extra...)
+		}
+		ch <- prometheus.MustNewConstMetric(d, prometheus.GaugeValue, v, labelVals...)
 	}
 	now := time.Now()
 	emit(r.descs.notBefore, float64(c.NotBefore.Unix()))
@@ -267,6 +279,12 @@ func (r *Registry) emitItem(ch chan<- prometheus.Metric, ki keyedItem, withDisc 
 	emit(r.descs.expiresIn, c.NotAfter.Sub(now).Seconds())
 	emit(r.descs.validSince, now.Sub(c.NotBefore).Seconds())
 	emit(r.descs.certError, 0)
+	for _, dns := range c.DNSNames {
+		emit(r.descs.certSAN, 1, dns, "dns")
+	}
+	for _, ip := range c.IPAddresses {
+		emit(r.descs.certSAN, 1, ip.String(), "address")
+	}
 }
 
 // emitCRLMetrics walks every Bundle's RevocationItems and emits the

--- a/pkg/registry/collector.go
+++ b/pkg/registry/collector.go
@@ -279,11 +279,21 @@ func (r *Registry) emitItem(ch chan<- prometheus.Metric, ki keyedItem, withDisc 
 	emit(r.descs.expiresIn, c.NotAfter.Sub(now).Seconds())
 	emit(r.descs.validSince, now.Sub(c.NotBefore).Seconds())
 	emit(r.descs.certError, 0)
+	seenSAN := make(map[string]struct{}, len(c.DNSNames)+len(c.IPAddresses))
 	for _, dns := range c.DNSNames {
+		if _, dup := seenSAN["dns\x00"+dns]; dup {
+			continue
+		}
+		seenSAN["dns\x00"+dns] = struct{}{}
 		emit(r.descs.certSAN, 1, dns, "dns")
 	}
 	for _, ip := range c.IPAddresses {
-		emit(r.descs.certSAN, 1, ip.String(), "address")
+		v := ip.String()
+		if _, dup := seenSAN["address\x00"+v]; dup {
+			continue
+		}
+		seenSAN["address\x00"+v] = struct{}{}
+		emit(r.descs.certSAN, 1, v, "address")
 	}
 }
 

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -39,6 +39,10 @@ type Config struct {
 	// config-loading layer; passing the zero value here disables the
 	// metric entirely.
 	ExposeExpired          bool
+	// ExposeSAN gates `x509_cert_san`, which emits one series per
+	// Subject Alternative Name (DNS or IP) on each certificate.
+	// Off by default to keep `/metrics` lean.
+	ExposeSAN              bool
 	// ExposeDiagnostics enables the exporter's self-introspection
 	// metrics (parse / kube API latencies, source scope, namespace
 	// informer queue depth). Off by default.

--- a/pkg/registry/registry_test.go
+++ b/pkg/registry/registry_test.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"log/slog"
 	"math/big"
+	"net"
 	"strings"
 	"testing"
 	"time"
@@ -36,6 +37,71 @@ func mkCert(t *testing.T, cn string, serial int64) *x509.Certificate {
 	der, _ := x509.CreateCertificate(rand.Reader, tpl, tpl, &key.PublicKey, key)
 	x, _ := x509.ParseCertificate(der)
 	return x
+}
+
+func mkCertWithDuplicateSAN(t *testing.T, cn string, serial int64) *x509.Certificate {
+	t.Helper()
+	key, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	tpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(serial),
+		Subject:               pkix.Name{CommonName: cn, Organization: []string{"Acme"}},
+		Issuer:                pkix.Name{CommonName: "issuer", Organization: []string{"Acme"}},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		BasicConstraintsValid: true,
+		DNSNames:              []string{"example.com", "example.com", "foo.bar"},
+		IPAddresses:           []net.IP{net.ParseIP("10.0.0.1"), net.ParseIP("10.0.0.1")},
+	}
+	der, _ := x509.CreateCertificate(rand.Reader, tpl, tpl, &key.PublicKey, key)
+	x, _ := x509.ParseCertificate(der)
+	return x
+}
+
+func TestSANDedup(t *testing.T) {
+	r := New(Config{ExposeSAN: true}, nopLogger())
+	r.Upsert(bundleFile(mkCertWithDuplicateSAN(t, "leaf", 1), "/etc/leaf.pem"))
+
+	reg := prometheus.NewRegistry()
+	if err := reg.Register(r); err != nil {
+		t.Fatal(err)
+	}
+	mfs, err := reg.Gather()
+	if err != nil {
+		t.Fatalf("Gather failed (duplicate SANs not deduplicated): %v", err)
+	}
+	for _, mf := range mfs {
+		if *mf.Name != "x509_cert_san" {
+			continue
+		}
+		if len(mf.Metric) != 3 {
+			t.Fatalf("want 3 SAN series after dedup, got %d", len(mf.Metric))
+		}
+		var dnsCount, ipCount int
+		for _, m := range mf.Metric {
+			var sanType string
+			for _, l := range m.Label {
+				if *l.Name == "SAN_type" {
+					sanType = *l.Value
+				}
+			}
+			switch sanType {
+			case "dns":
+				dnsCount++
+			case "address":
+				ipCount++
+			default:
+				t.Errorf("unexpected SAN_type: %s", sanType)
+			}
+		}
+		if dnsCount != 2 {
+			t.Errorf("want 2 DNS SAN series, got %d", dnsCount)
+		}
+		if ipCount != 1 {
+			t.Errorf("want 1 IP SAN series, got %d", ipCount)
+		}
+		return
+	}
+	t.Error("x509_cert_san metric family not found")
 }
 
 func bundleFile(c *x509.Certificate, path string) cert.Bundle {


### PR DESCRIPTION
Introduces a new gauge metric `x509_cert_san` to expose Subject Alternative Names (SANs) from X.509 certificates, with detailed metadata labels for enhanced monitoring and troubleshooting.

config:
`metrics.exposeSAN`

Key features:
- Tracks both DNS names and IP addresses via `SAN_type` label ("dns" or "address")
- Includes `SAN_value` label to store the actual DNS/IP entry
- Adds base labels:`filename`,`filepath`,`issuer_CN`,`subject_CN`,`serial_number`, etc.

Example metric output:
```
# HELP x509_cert_san Indicates the Subject Alternative Names (DNS or IP) present in the certificate
# TYPE x509_cert_san gauge
x509_cert_san{SAN_type="address",SAN_value="10.103.97.2",filename="apiserver.crt",filepath="/file/go/src/test/apiserver.crt",issuer_CN="kubernetes",serial_number="8451564427851205067",subject_CN="kube-apiserver"} 1
...
x509_cert_san{SAN_type="address",SAN_value="10.77.0.1",filename="apiserver.crt",filepath="/file/go/src/test/apiserver.crt",issuer_CN="kubernetes",serial_number="8451564427851205067",subject_CN="kube-apiserver"} 1
x509_cert_san{SAN_type="address",SAN_value="127.0.0.1",filename="apiserver.crt",filepath="/file/go/src/test/apiserver.crt",issuer_CN="kubernetes",serial_number="8451564427851205067",subject_CN="kube-apiserver"} 1
...
x509_cert_san{SAN_type="dns",SAN_value="kubernetes.default.svc.cluster.local",filename="apiserver.crt",filepath="/file/go/src/test/apiserver.crt",issuer_CN="kubernetes",serial_number="8451564427851205067",subject_CN="kube-apiserver"} 1
x509_cert_san{SAN_type="dns",SAN_value="localhost",filename="apiserver.crt",filepath="/file/go/src/test/apiserver.crt",issuer_CN="kubernetes",serial_number="8451564427851205067",subject_CN="kube-apiserver"} 1
x509_cert_san{SAN_type="dns",SAN_value="node1",filename="apiserver.crt",filepath="/file/go/src/test/apiserver.crt",issuer_CN="kubernetes",serial_number="8451564427851205067",subject_CN="kube-apiserver"} 1
```
This implementation enables granular filtering of SAN entries (e.g., finding all certificates with a specific DNS name) while preserving full certificate context for cross-referencing with existing metrics.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable option (`exposeSANMetric`) to expose certificate Subject Alternative Name data via a new `x509_cert_san` Prometheus metric (one series per SAN DNS/IP entry).
* **Bug Fixes**
  * Deduplicates repeated SAN entries so duplicate DNS/IP values on a certificate don’t produce extra metric series.
* **Chores**
  * Updated default configuration to keep SAN metrics disabled unless explicitly enabled.
* **Tests**
  * Added coverage to verify SAN deduplication behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->