### PR TITLE
build(dagger): derive the CLI version from dagger.json everywhere

### DIFF
--- a/.github/actions/dagger/action.yml
+++ b/.github/actions/dagger/action.yml
@@ -1,0 +1,42 @@
+name: "Dagger call"
+description: >-
+  Run a Dagger function at the version this repo's module requires.
+  Reads `engineVersion` from dagger.json — the single source of truth for
+  the Dagger version — so no workflow ever repeats it. Also the one place
+  dagger/dagger-for-github is referenced, so its SHA pin lives in a
+  single file for Renovate to bump.
+
+inputs:
+  args:
+    description: >-
+      Arguments passed to the verb (for `call`: the function and its
+      flags). Empty for verbs that take none, e.g. `develop`.
+    required: false
+    default: ""
+  verb:
+    description: "Dagger verb to invoke."
+    required: false
+    default: call
+
+runs:
+  using: composite
+  steps:
+    # dagger.json is read from the checked-out tree, so callers must run
+    # actions/checkout first (they all do).
+    - id: version
+      shell: bash
+      run: |
+        version=$(sed -n 's/.*"engineVersion"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' dagger.json | head -n1)
+        if [ -z "$version" ]; then
+          echo "::error file=dagger.json::no engineVersion found" >&2
+          exit 1
+        fi
+        echo "version=$version" >> "$GITHUB_OUTPUT"
+        echo "Dagger $version (from dagger.json)"
+
+    - uses: dagger/dagger-for-github@27b130bf0f79a7f6fbbbe0fbca6760dc9bb40a77 # v8
+      with:
+        version: ${{ steps.version.outputs.version }}
+        dagger-flags: --progress=logs
+        verb: ${{ inputs.verb }}
+        args: ${{ inputs.args }}

--- a/.github/workflows/chart-readme.yaml
+++ b/.github/workflows/chart-readme.yaml
@@ -45,17 +45,11 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           fetch-depth: 1
-      - uses: dagger/dagger-for-github@27b130bf0f79a7f6fbbbe0fbca6760dc9bb40a77 # v8
+      - uses: ./.github/actions/dagger
         with:
-          version: latest
-          dagger-flags: --progress=logs
-          verb: call
           args: helm-docs export --path=chart/README.md
-      - uses: dagger/dagger-for-github@27b130bf0f79a7f6fbbbe0fbca6760dc9bb40a77 # v8
+      - uses: ./.github/actions/dagger
         with:
-          version: latest
-          dagger-flags: --progress=logs
-          verb: call
           args: chart-schema export --path=chart/values.schema.json
       - name: Fail if chart docs are stale
         run: |
@@ -79,17 +73,11 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           fetch-depth: 1
-      - uses: dagger/dagger-for-github@27b130bf0f79a7f6fbbbe0fbca6760dc9bb40a77 # v8
+      - uses: ./.github/actions/dagger
         with:
-          version: latest
-          dagger-flags: --progress=logs
-          verb: call
           args: helm-docs export --path=chart/README.md
-      - uses: dagger/dagger-for-github@27b130bf0f79a7f6fbbbe0fbca6760dc9bb40a77 # v8
+      - uses: ./.github/actions/dagger
         with:
-          version: latest
-          dagger-flags: --progress=logs
-          verb: call
           args: chart-schema export --path=chart/values.schema.json
       - name: Commit regenerated chart docs if changed
         run: |

--- a/.github/workflows/dagger-module.yaml
+++ b/.github/workflows/dagger-module.yaml
@@ -49,8 +49,17 @@ jobs:
       # can be pushed back onto it. Credentials are deliberately
       # persisted here — unlike every other job in this repo, this one
       # needs git write access.
+      #
+      # `repository` must follow `ref`: on a fork PR, head.ref names a
+      # branch that only exists in the fork, so checking it out against
+      # the base repo would fail (or resolve a same-named base branch).
+      # Safe under `pull_request` — the token is read-only and no secrets
+      # are exposed, and the default checkout already contains the fork's
+      # code via the merge commit. The fork path only ever reads: pushing
+      # is gated on IS_FORK below.
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
+          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
           ref: ${{ github.event.pull_request.head.ref || github.ref }}
           fetch-depth: 1
 

--- a/.github/workflows/dagger-module.yaml
+++ b/.github/workflows/dagger-module.yaml
@@ -1,0 +1,87 @@
+name: Dagger module
+
+# Keeps dagger/go.mod + go.sum consistent with the module's bindings.
+#
+# Why this exists: Renovate bumps the Dagger version strings (dagger.json
+# engineVersion + the dagger.io/dagger SDK, grouped into one PR) but
+# cannot regenerate the module's bindings. The generated code drives
+# dagger/go.mod's transitive deps — a newer SDK relocates packages like
+# `querybuilder` — so after a bump the committed go.mod is stale. Nothing
+# in CI notices, because `dagger call` regenerates inside its own sandbox;
+# only host `go` tooling (`task go:tidy`, `go build ./dagger`) breaks, on
+# maintainers' machines, days later.
+#
+# So this job runs `dagger develop` for them: on a same-repo PR (which
+# includes every renovate/** branch) it commits the result, so the PR
+# lands complete with no human step. On a fork PR it can't push, so it
+# reports the drift and fails.
+
+on:
+  pull_request:
+    paths:
+      - "dagger.json"
+      - "dagger/**"
+  push:
+    branches: [main]
+    paths:
+      - "dagger.json"
+      - "dagger/**"
+  # Lets a maintainer exercise this job on any branch without waiting for
+  # a Dagger bump to touch the trigger paths.
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  DAGGER_NO_NAG: "1"
+  DAGGER_CLOUD_TOKEN: ""
+  DO_NOT_TRACK: "1"
+
+jobs:
+  sync:
+    name: Sync generated deps
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # commits the regenerated dagger/go.mod on same-repo refs
+    steps:
+      # Checkout the PR's head branch (not the merge commit) so a commit
+      # can be pushed back onto it. Credentials are deliberately
+      # persisted here — unlike every other job in this repo, this one
+      # needs git write access.
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          ref: ${{ github.event.pull_request.head.ref || github.ref }}
+          fetch-depth: 1
+
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
+        with:
+          go-version-file: go.mod
+
+      # Regenerates dagger.gen.go + internal/ (both gitignored) and
+      # realigns dagger/go.mod with what they import.
+      - uses: ./.github/actions/dagger
+        with:
+          verb: develop
+
+      - run: go -C dagger mod tidy
+
+      - name: Commit regenerated module deps if changed
+        env:
+          IS_FORK: ${{ github.event.pull_request.head.repo.fork || false }}
+        run: |
+          if git diff --quiet -- dagger/go.mod dagger/go.sum; then
+            echo "dagger/go.mod already in sync."
+            exit 0
+          fi
+          git --no-pager diff --stat -- dagger/go.mod dagger/go.sum
+          if [ "$IS_FORK" = "true" ]; then
+            echo "::error::dagger/go.mod is out of sync with the module bindings." \
+                 "Run 'task dagger:develop' and commit the result." >&2
+            exit 1
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add dagger/go.mod dagger/go.sum
+          git commit -m "build(dagger): regenerate module deps"
+          git push

--- a/.github/workflows/dagger-module.yaml
+++ b/.github/workflows/dagger-module.yaml
@@ -15,6 +15,17 @@ name: Dagger module
 # includes every renovate/** branch) it commits the result, so the PR
 # lands complete with no human step. On a fork PR it can't push, so it
 # reports the drift and fails.
+#
+# The push uses the repo's GitHub App token (same App as renovate.yaml),
+# NOT the workflow's GITHUB_TOKEN — for the same reason renovate.yaml
+# does: events caused by GITHUB_TOKEN don't trigger workflows, so a
+# GITHUB_TOKEN push would leave the PR's new head SHA with no
+# `pull_request` runs at all, and branch protection would hold the PR on
+# "expected — waiting for status" until someone re-runs checks by hand.
+# The App push retriggers CI like any human push. The companion setting
+# is `gitIgnoredAuthors` in renovate.json5: without it, Renovate treats
+# a branch carrying our bot commit as "modified by another author" and
+# stops rebasing/updating it.
 
 on:
   pull_request:
@@ -42,13 +53,25 @@ jobs:
   sync:
     name: Sync generated deps
     runs-on: ubuntu-latest
-    permissions:
-      contents: write # commits the regenerated dagger/go.mod on same-repo refs
+    # No write permission on GITHUB_TOKEN: the push (when it happens)
+    # rides on the App token minted below, precisely so it does NOT come
+    # from GITHUB_TOKEN (see header). Inherits contents: read.
     steps:
+      # Mint an App token for the push. Skipped on fork PRs twice over:
+      # GitHub withholds the App secrets from fork-triggered runs anyway,
+      # and the fork path below never pushes — it only reports drift.
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+        id: app-token
+        if: ${{ !github.event.pull_request.head.repo.fork }}
+        with:
+          client-id: ${{ secrets.RENOVATE_APP_CLIENT_ID }}
+          private-key: ${{ secrets.RENOVATE_APP_PRIVATE_KEY }}
+
       # Checkout the PR's head branch (not the merge commit) so a commit
       # can be pushed back onto it. Credentials are deliberately
       # persisted here — unlike every other job in this repo, this one
-      # needs git write access.
+      # needs git write access. On forks the app-token step is skipped
+      # and this falls back to the (read-only) GITHUB_TOKEN.
       #
       # `repository` must follow `ref`: on a fork PR, head.ref names a
       # branch that only exists in the fork, so checking it out against
@@ -59,6 +82,7 @@ jobs:
       # is gated on IS_FORK below.
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
+          token: ${{ steps.app-token.outputs.token || github.token }}
           repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
           ref: ${{ github.event.pull_request.head.ref || github.ref }}
           fetch-depth: 1

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -103,11 +103,8 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           fetch-depth: 1
-      - uses: dagger/dagger-for-github@27b130bf0f79a7f6fbbbe0fbca6760dc9bb40a77 # v8
+      - uses: ./.github/actions/dagger
         with:
-          version: latest
-          dagger-flags: --progress=logs
-          verb: call
           args: lint-go
 
   lint-helm:
@@ -122,11 +119,8 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           fetch-depth: 1
-      - uses: dagger/dagger-for-github@27b130bf0f79a7f6fbbbe0fbca6760dc9bb40a77 # v8
+      - uses: ./.github/actions/dagger
         with:
-          version: latest
-          dagger-flags: --progress=logs
-          verb: call
           args: lint-helm
 
   lint-renovate:
@@ -141,11 +135,8 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           fetch-depth: 1
-      - uses: dagger/dagger-for-github@27b130bf0f79a7f6fbbbe0fbca6760dc9bb40a77 # v8
+      - uses: ./.github/actions/dagger
         with:
-          version: latest
-          dagger-flags: --progress=logs
-          verb: call
           args: lint-renovate
 
   lint-markdown:
@@ -160,9 +151,6 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           fetch-depth: 1
-      - uses: dagger/dagger-for-github@27b130bf0f79a7f6fbbbe0fbca6760dc9bb40a77 # v8
+      - uses: ./.github/actions/dagger
         with:
-          version: latest
-          dagger-flags: --progress=logs
-          verb: call
           args: lint-markdown

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -64,11 +64,8 @@ jobs:
           # gitleaks scans the working tree, not git history — shallow.
           fetch-depth: 1
           persist-credentials: false
-      - uses: dagger/dagger-for-github@27b130bf0f79a7f6fbbbe0fbca6760dc9bb40a77 # v8
+      - uses: ./.github/actions/dagger
         with:
-          version: latest
-          dagger-flags: --progress=logs
-          verb: call
           args: gitleaks
 
   # Reachability-based vulnerability check for Go code. Routed through
@@ -87,11 +84,8 @@ jobs:
         with:
           fetch-depth: 1
           persist-credentials: false
-      - uses: dagger/dagger-for-github@27b130bf0f79a7f6fbbbe0fbca6760dc9bb40a77 # v8
+      - uses: ./.github/actions/dagger
         with:
-          version: latest
-          dagger-flags: --progress=logs
-          verb: call
           args: govulncheck
 
   # Filesystem scan: Go module deps + lockfiles. Catches CVEs that
@@ -109,11 +103,8 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           persist-credentials: false
-      - uses: dagger/dagger-for-github@27b130bf0f79a7f6fbbbe0fbca6760dc9bb40a77 # v8
+      - uses: ./.github/actions/dagger
         with:
-          version: latest
-          dagger-flags: --progress=logs
-          verb: call
           args: trivy --scan-type=fs
 
   # Helm/Kubernetes misconfig scan against the rendered chart.
@@ -128,9 +119,6 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           persist-credentials: false
-      - uses: dagger/dagger-for-github@27b130bf0f79a7f6fbbbe0fbca6760dc9bb40a77 # v8
+      - uses: ./.github/actions/dagger
         with:
-          version: latest
-          dagger-flags: --progress=logs
-          verb: call
           args: trivy --scan-type=config --scan-ref=chart

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -85,11 +85,8 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           fetch-depth: 1
-      - uses: dagger/dagger-for-github@27b130bf0f79a7f6fbbbe0fbca6760dc9bb40a77 # v8
+      - uses: ./.github/actions/dagger
         with:
-          version: latest
-          dagger-flags: --progress=logs
-          verb: call
           args: test
 
   helm-examples:
@@ -103,11 +100,8 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           fetch-depth: 1
-      - uses: dagger/dagger-for-github@27b130bf0f79a7f6fbbbe0fbca6760dc9bb40a77 # v8
+      - uses: ./.github/actions/dagger
         with:
-          version: latest
-          dagger-flags: --progress=logs
-          verb: call
           args: test-helm-examples
 
   helm-fixtures:
@@ -121,11 +115,8 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           fetch-depth: 1
-      - uses: dagger/dagger-for-github@27b130bf0f79a7f6fbbbe0fbca6760dc9bb40a77 # v8
+      - uses: ./.github/actions/dagger
         with:
-          version: latest
-          dagger-flags: --progress=logs
-          verb: call
           args: test-helm-fixtures
 
   e2e:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,7 +67,8 @@ everything.
 | Vuln scan (deps) | `task security:vuln-deps` | `dagger call trivy --scan-type=fs` |
 | Chart misconfig | `task security:chart-misconfig` | `dagger call trivy --scan-type=config --scan-ref=chart` |
 | Tidy go.mod | `task go:tidy` | `go mod tidy` on main + `dagger/` (direct, no Dagger) |
-| Bump Go deps | `task go:upgrade` | `go get -u ./...` + tidy on main + `dagger/` (direct) |
+| Bump Go deps | `task go:upgrade` | `go get -u ./...` + tidy on the **main module only** — the dagger module's SDK is tied to `dagger.json` engineVersion |
+| Realign dagger module | `task dagger:develop` | `dagger develop` + tidy — only needed if you edit `dagger.json` by hand; CI does it for Renovate's bumps |
 | Renovate dry-run | `task renovate:plan` | extracts deps + lists planned bumps without modifying files (debug `renovate.json5`) |
 | Renovate apply | `task renovate:patch` | applies the same bumps to the working tree, format-preserving, best-effort (skips ambiguous cases) |
 | Render chart README | `task doc:helm` | `dagger call helm-docs export --path=chart/README.md` |
@@ -293,6 +294,47 @@ Every other reference is intentionally loose:
 
 To bump Go: change `go.mod`'s `go` directive (or let Renovate do it).
 Everything else either auto-updates or auto-resolves at build time.
+
+## Dagger version: single source of truth
+
+`dagger.json`'s `engineVersion` is the only place the Dagger version is
+written. A module refuses to run on a CLI older than that value, so every
+consumer **reads** it instead of repeating it:
+
+- `dagger/go.mod`'s `dagger.io/dagger` SDK — bumped by Renovate in the
+  same PR (the `dagger SDK + engine` group), then realigned by
+  `dagger develop`, which also settles the transitive deps the generated
+  bindings pull in (e.g. `querybuilder`, whose import path moves between
+  SDK versions).
+- The dev shell — `flake.nix`'s `shellHook` runs
+  `scripts/dagger-cli.sh`, which reads `engineVersion`, fetches that
+  exact CLI once into `${XDG_CACHE_HOME}/x509-certificate-exporter/`,
+  and verifies it against the release's `checksums.txt` before use.
+  Cache hit is a `test -x`, so the shell stays instant and works offline
+  once warm.
+- CI — `.github/actions/dagger` (a local composite action) reads
+  `engineVersion` and passes it to `dagger/dagger-for-github`. That
+  action's SHA pin lives in that one file; workflows just say
+  `uses: ./.github/actions/dagger` + `args:`.
+
+Deliberate non-choices, so nobody "fixes" them back:
+
+- **The CLI is not a Nix package.** Neither the `github:dagger/nix`
+  input (a separate release train that lags core, so it silently drifts
+  below `engineVersion`) nor a local `fetchurl` (version + four per-arch
+  hashes to hand-maintain). Both store a *second* copy of the version
+  that nothing can derive from the manifest — precisely what drifts and
+  breaks every `dagger call`. Fetching the binary costs nothing in
+  reproducibility terms anyway: Dagger pulls its engine as an OCI image
+  by tag at run time, in CI and locally.
+- **No version pinned in workflows.** 15 copies of `version:` is 15
+  chances to drift.
+
+To bump Dagger: let the Renovate `dagger SDK + engine` PR land. The
+`Dagger module` workflow commits the regenerated `dagger/go.mod` onto
+that PR branch, shell and CI follow from `engineVersion`, and there is
+nothing to do by hand. If you edit `dagger.json` yourself, run
+`task dagger:develop`.
 
 ## Release pipeline
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -109,11 +109,25 @@ tasks:
       - go -C dagger mod tidy
 
   go:upgrade:
-    desc: Upgrade all Go deps to latest then tidy (main module + ./dagger)
+    desc: Upgrade the main module's Go deps to latest then tidy
+    # Main module only. The dagger/ module is deliberately excluded: its
+    # `dagger.io/dagger` SDK must equal dagger.json's engineVersion (the
+    # single source of truth), and `go get -u` there would desync it and
+    # break against the generated bindings — a newer SDK relocates
+    # packages like `querybuilder`. The Dagger version moves via the
+    # Renovate "dagger SDK + engine" PR; `task dagger:develop` realigns
+    # the module afterwards (CI does it automatically on that PR).
     cmds:
       - go get -u ./...
       - go mod tidy
-      - go -C dagger get -u ./...
+
+  dagger:develop:
+    desc: "Regenerate the Dagger module bindings and realign dagger/go.mod (after a dagger.json engineVersion change)"
+    # Local counterpart of the `Dagger module` workflow. Only needed when
+    # you edit dagger.json yourself — for Renovate's bumps, CI already
+    # commits the result onto the PR.
+    cmds:
+      - dagger develop
       - go -C dagger mod tidy
 
   nix:update:

--- a/flake.lock
+++ b/flake.lock
@@ -1,25 +1,5 @@
 {
   "nodes": {
-    "dagger": {
-      "inputs": {
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1778107833,
-        "narHash": "sha256-q5XQep2mpgTPiWwuYB1+L2dsFeACT6sHx8J939iM+HE=",
-        "owner": "dagger",
-        "repo": "nix",
-        "rev": "873cc22ba46b73d4a6c1aa6c102ef3aabc736496",
-        "type": "github"
-      },
-      "original": {
-        "owner": "dagger",
-        "repo": "nix",
-        "type": "github"
-      }
-    },
     "flake-utils": {
       "inputs": {
         "systems": "systems"
@@ -56,7 +36,6 @@
     },
     "root": {
       "inputs": {
-        "dagger": "dagger",
         "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -4,13 +4,9 @@
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
     flake-utils.url = "github:numtide/flake-utils";
-    # Dagger is not in nixpkgs; the upstream maintains its own flake.
-    # https://github.com/dagger/nix
-    dagger.url = "github:dagger/nix";
-    dagger.inputs.nixpkgs.follows = "nixpkgs";
   };
 
-  outputs = { self, nixpkgs, flake-utils, dagger }:
+  outputs = { self, nixpkgs, flake-utils }:
     flake-utils.lib.eachDefaultSystem (system:
       let
         pkgs = nixpkgs.legacyPackages.${system};
@@ -89,8 +85,27 @@
           # version nixpkgs currently exposes, and Go's GOTOOLCHAIN=auto
           # mechanism transparently downloads the exact toolchain declared
           # in go.mod. Single source of truth: the `go` directive in go.mod.
+          # The Dagger CLI is deliberately NOT a Nix package here. Its
+          # version must equal `dagger.json`'s engineVersion (a module
+          # refuses to run on an older CLI), and any Nix packaging —
+          # upstream's `github:dagger/nix` input or a local fetchurl —
+          # carries a *second* copy of that version (plus per-arch
+          # hashes) that nothing can derive from the manifest. That
+          # duplication is what silently drifts and breaks every
+          # `dagger call`. Instead `scripts/dagger-cli.sh` reads
+          # engineVersion, fetches the matching binary once into a
+          # per-version cache, and verifies it against the release's
+          # checksums.txt. Renovate bumps engineVersion; the shell
+          # follows with zero manual steps.
+          shellHook = ''
+            if daggerBin=$(${./scripts/dagger-cli.sh}); then
+              PATH="$daggerBin:$PATH"
+            else
+              echo "warning: Dagger CLI unavailable; 'task lint:*' / 'test:*' will fail" >&2
+            fi
+          '';
+
           packages = [
-            dagger.packages.${system}.dagger
             goSizeAnalyzer
             goreleaser
           ] ++ (with pkgs; [

--- a/renovate.json5
+++ b/renovate.json5
@@ -57,6 +57,18 @@
     enabled: true,
   },
 
+  // The `Dagger module` workflow pushes a follow-up commit (regenerated
+  // dagger/go.mod) onto Renovate's own dagger PR branches, authored as
+  // github-actions[bot]. Without this allowance Renovate would treat
+  // those branches as "modified by another author" and stop
+  // rebasing/updating them — every dagger bump would then need a manual
+  // rebase checkbox. Listing the bot author keeps Renovate in charge of
+  // its branches; if it rebases one, the sync commit is dropped and the
+  // workflow simply re-adds it on the next (App-token-triggered) run.
+  gitIgnoredAuthors: [
+    "41898282+github-actions[bot]@users.noreply.github.com",
+  ],
+
   customManagers: [
     // K3s image pinned for both the dev cluster bootstrap and the
     // throwaway e2e cluster (Taskfile var K3S_IMAGE). Tag format

--- a/renovate.json5
+++ b/renovate.json5
@@ -157,13 +157,19 @@
       depNameTemplate: "gotest.tools/gotestsum",
       datasourceTemplate: "go",
     },
-    // Dagger engine version pinned in dagger.json. Must stay in lockstep
-    // with the `dagger.io/dagger` SDK in dagger/go.mod — when the SDK
-    // bumps but the engine doesn't, `dagger develop` runs implicitly on
-    // every `dagger call` and fails to fetch the matching SDK, breaking
-    // every `task lint:*` / `task test:unit` / etc. The matching
-    // packageRule below groups this regex bump with the gomod bump into
-    // one PR.
+    // Dagger engine version pinned in dagger.json — the SINGLE source of
+    // truth for the Dagger version repo-wide. Must stay in lockstep with
+    // the `dagger.io/dagger` SDK in dagger/go.mod: when the SDK bumps but
+    // the engine doesn't, `dagger develop` runs implicitly on every
+    // `dagger call` and fails to fetch the matching SDK, breaking every
+    // `task lint:*` / `task test:unit` / etc. The packageRule below groups
+    // this regex bump with the gomod bump into one PR.
+    //
+    // Nothing else needs a manager: the dev-shell CLI
+    // (scripts/dagger-cli.sh, via the flake) and CI
+    // (.github/actions/dagger) both READ engineVersion at run time
+    // instead of repeating it. Don't add pins for them — a second copy of
+    // the version is exactly what drifts.
     {
       customType: "regex",
       managerFilePatterns: ["/^dagger\\.json$/"],
@@ -290,6 +296,11 @@
     // dagger/go.mod and the engineVersion in dagger.json must land
     // together (see the engine regex manager comment for the failure
     // mode). Listed AFTER the gomod groupings so this rule wins.
+    //
+    // That single PR is enough to move the whole toolchain: the dev shell
+    // and CI derive the CLI version from engineVersion, and the
+    // `Dagger module` workflow commits the regenerated dagger/go.mod onto
+    // the PR branch. No follow-up commit, no maintainer step.
     {
       matchPackageNames: ["dagger.io/dagger"],
       groupName: "dagger SDK + engine",

--- a/scripts/dagger-cli.sh
+++ b/scripts/dagger-cli.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# Provision the Dagger CLI at exactly the version the module requires.
+#
+# `dagger.json`'s `engineVersion` is the single source of truth for the
+# Dagger version across this repo (SDK in dagger/go.mod, CLI here, CI
+# workflows). A module refuses to run on a CLI older than its
+# engineVersion, so deriving the CLI version from that file — rather than
+# pinning it a second time — makes drift structurally impossible.
+#
+# The CLI is not `go install`-able (dagger.io/dagger is the SDK library;
+# the CLI lives in the engine monorepo and ships as prebuilt binaries),
+# and Dagger downloads its engine as an OCI image at runtime anyway, so
+# fetching the binary costs nothing in reproducibility terms. We do NOT
+# pipe a remote installer into a shell: the tarball is downloaded, its
+# SHA-256 is checked against the release's own checksums.txt, and only
+# then is it unpacked.
+#
+# Downloads land in a per-version cache and are reused, so the common
+# path is a single `test -x`. Prints the directory holding the binary on
+# stdout (for PATH); all logging goes to stderr.
+set -euo pipefail
+
+# Resolve the repo root. `git` first because the flake's shellHook runs
+# this script from the Nix store (where $0's parent is a store path, not
+# the checkout); the $0-relative fallback keeps direct invocation working
+# outside a git checkout.
+if [ -n "${DAGGER_CLI_REPO_ROOT:-}" ]; then
+  repo_root=$DAGGER_CLI_REPO_ROOT
+elif repo_root=$(git rev-parse --show-toplevel 2>/dev/null) && [ -n "$repo_root" ]; then
+  :
+else
+  repo_root=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+fi
+manifest="${repo_root}/dagger.json"
+
+[ -r "$manifest" ] || { echo "dagger-cli: missing $manifest" >&2; exit 1; }
+
+# Extract "engineVersion": "vX.Y.Z" without requiring jq — this runs from
+# the flake's shellHook, before any project tooling is guaranteed present.
+version=$(sed -n 's/.*"engineVersion"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "$manifest" | head -n1)
+[ -n "$version" ] || { echo "dagger-cli: no engineVersion in $manifest" >&2; exit 1; }
+
+case "$(uname -s)" in
+  Linux)  os=linux ;;
+  Darwin) os=darwin ;;
+  *) echo "dagger-cli: unsupported OS $(uname -s)" >&2; exit 1 ;;
+esac
+case "$(uname -m)" in
+  x86_64|amd64)  arch=amd64 ;;
+  aarch64|arm64) arch=arm64 ;;
+  *) echo "dagger-cli: unsupported arch $(uname -m)" >&2; exit 1 ;;
+esac
+
+cache_root="${XDG_CACHE_HOME:-${HOME}/.cache}/x509-certificate-exporter/dagger"
+target_dir="${cache_root}/${version}-${os}-${arch}"
+target_bin="${target_dir}/dagger"
+
+# Fast path: already provisioned. Keeps `nix develop` instant and works
+# offline once the cache is warm.
+if [ -x "$target_bin" ]; then
+  printf '%s\n' "$target_dir"
+  exit 0
+fi
+
+tarball="dagger_${version}_${os}_${arch}.tar.gz"
+base_url="https://github.com/dagger/dagger/releases/download/${version}"
+
+echo "dagger-cli: provisioning ${version} (${os}/${arch})" >&2
+
+tmp=$(mktemp -d)
+# shellcheck disable=SC2064 # expand tmp now, not at trap time
+trap "rm -rf '$tmp'" EXIT
+
+curl -fsSL --retry 3 -o "${tmp}/${tarball}" "${base_url}/${tarball}"
+curl -fsSL --retry 3 -o "${tmp}/checksums.txt" "${base_url}/checksums.txt"
+
+expected=$(awk -v f="$tarball" '$2 == f || $2 == "*" f { print $1 }' "${tmp}/checksums.txt" | head -n1)
+[ -n "$expected" ] || { echo "dagger-cli: ${tarball} absent from checksums.txt" >&2; exit 1; }
+
+if command -v sha256sum >/dev/null 2>&1; then
+  actual=$(sha256sum "${tmp}/${tarball}" | cut -d' ' -f1)
+else
+  actual=$(shasum -a 256 "${tmp}/${tarball}" | cut -d' ' -f1)
+fi
+
+if [ "$actual" != "$expected" ]; then
+  echo "dagger-cli: checksum mismatch for ${tarball}" >&2
+  echo "  expected ${expected}" >&2
+  echo "  actual   ${actual}" >&2
+  exit 1
+fi
+
+tar -xzf "${tmp}/${tarball}" -C "$tmp" dagger
+chmod +x "${tmp}/dagger"
+
+# Publish atomically: a concurrent shell either sees no dir or a complete
+# one, never a half-extracted binary.
+mkdir -p "$cache_root"
+staging=$(mktemp -d "${cache_root}/.staging-XXXXXX")
+mv "${tmp}/dagger" "${staging}/dagger"
+mv "$staging" "$target_dir" 2>/dev/null || rm -rf "$staging"
+
+[ -x "$target_bin" ] || { echo "dagger-cli: provisioning failed" >&2; exit 1; }
+printf '%s\n' "$target_dir"


### PR DESCRIPTION
## Problem

The Dagger version was written in **four** places that drifted independently:

| Where | What it was |
|---|---|
| `dagger.json` | `engineVersion` |
| `dagger/go.mod` | `dagger.io/dagger` SDK |
| `flake.nix` | the CLI (via the `github:dagger/nix` input) |
| 4 workflows | `version:` on 15 `dagger-for-github` steps (`latest`) |

A module refuses to run on a CLI older than its `engineVersion`, so any skew broke
every `dagger call` locally — including `nix develop --command task test:e2e` in CI.
That is exactly what happened after `b6f58e6`: engine + SDK moved to v0.21.7 while
the flake input still shipped v0.21.6, and `dagger/go.mod` was left stale (a newer
SDK relocates `querybuilder`), so host `go` tooling broke while CI stayed green
because `dagger call` regenerates in its own sandbox.

## Approach

`dagger.json`'s `engineVersion` becomes the single value written anywhere; every
consumer **reads** it:

- **Dev shell** — `flake.nix`'s `shellHook` runs `scripts/dagger-cli.sh`, which reads
  `engineVersion`, fetches that exact CLI once into a per-version cache, and verifies
  its SHA-256 against the release's own `checksums.txt` before use. Cache hit is a
  `test -x` (8 ms), so the shell stays instant and works offline once warm.
- **CI** — a local composite action `.github/actions/dagger` reads `engineVersion` and
  passes it to `dagger/dagger-for-github`. Workflows now say `uses: ./.github/actions/dagger`
  + `args:`; the action's SHA pin lives in that one file.
- **SDK** — Renovate bumps it with `engineVersion` in one PR (`dagger SDK + engine`
  group), and the new `Dagger module` workflow runs `dagger develop` + `go mod tidy`
  and **commits the regenerated `dagger/go.mod` onto the PR branch**. Fork PRs can't be
  pushed to, so there it reports the drift and fails.

Net effect: a Dagger bump is one Renovate PR that lands complete, with no maintainer
step. `task dagger:develop` remains for hand-edits of `dagger.json`.

### Deliberate non-choices (documented in `flake.nix` + `CLAUDE.md`)

- **The CLI is not a Nix package.** Neither the `github:dagger/nix` input (separate
  release train, lags core, silently drifts below `engineVersion`) nor a local
  `fetchurl` (version + four per-arch hashes to hand-maintain). Both store a *second*
  copy of the version that nothing derives from the manifest.
- **Fetching the binary costs nothing in reproducibility terms**: Dagger pulls its
  engine as an OCI image *by tag* at run time anyway, in CI and locally. GitHub Actions
  stay SHA-pinned.
- **No `version:` pinned in workflows** — 15 copies is 15 chances to drift.

## Validation

- `scripts/dagger-cli.sh`: cold 1.4 s / warm 8 ms; repo-root resolution tested from the
  root, a subdirectory, and the Nix store; `shellcheck` clean.
- `nix develop` → `dagger v0.21.7` == `engineVersion`; `dagger call lint-renovate` → exit 0.
- 15 steps converted; all workflow/action YAML parses; `renovate-config-validator` passes.
- `dagger-for-github` with empty `args` resolves to `dagger --progress=logs develop`
  (checked against the action's source, not assumed).

## Reviewer notes

- **`Dagger module` workflow has never run** — this PR doesn't touch its trigger paths.
  A `workflow_dispatch` is included so it can be exercised on this branch before we rely on it.
- **Renovate + `.github/actions/`**: the `github-actions` manager's default file patterns
  should cover `.github/actions/**/action.yml`, so the `dagger-for-github` SHA keeps getting
  bumped. Not verified locally (a local Renovate run hits Docker Hub anonymous rate limits);
  worth confirming on the first scheduled run, otherwise it needs an explicit
  `managerFilePatterns`.
- Diff is +343/−97. The line count grows: removing the duplication is small, the
  automation that replaces the manual steps (script, auto-sync workflow, composite action)
  and the comments explaining the non-choices are not. The win is 1 source of truth
  instead of 4, and zero human steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic Dagger CLI version resolution, caching, and integrity verification.
  * Added automated synchronization for generated Dagger module dependencies.
  * Added a reusable local action for Dagger-based workflows.

* **Improvements**
  * Standardized linting, security scans, tests, and chart validation on the configured Dagger version.
  * Added a dedicated task for regenerating Dagger bindings and dependencies.

* **Documentation**
  * Clarified Dagger version management and dependency update workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->