### PR TITLE
ci(renovate): group helm and renovate version write-sites into one PR each

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -288,8 +288,8 @@ Every other reference is intentionally loose:
 - `build/Dockerfile.seed-hostpath`'s `FROM golang:X.Y.Z-alpine` is the
   same deal (it compiles the e2e seed binary). It rides in the same
   Renovate PR as the two above — not because it's listed anywhere, but
-  because the dockerfile manager gives it depName `golang`, which the
-  `golang toolchain` group matches.
+  because the image is literally named `golang`, which the
+  `golang toolchain` group matches on packageName.
 - `flake.nix` uses unpinned `pkgs.go` for the same reason — the dev shell
   runs whatever Go nixpkgs ships, and `GOTOOLCHAIN=auto` handles the rest.
 - The CI workflows use `actions/setup-go@v5` with `go-version-file: go.mod`,
@@ -440,21 +440,22 @@ inside the official Renovate image, sandboxed by Dagger). Highlights:
   `golangciLint` / `gotestsumModule` Go install versions in the same
   file.
 - Go-toolchain bumps land in a single PR via `groupName: "golang
-  toolchain"`: `go.mod` + `dagger/go.mod` (depName `go`), plus
+  toolchain"`: `go.mod` + `dagger/go.mod` (packageName `go`), plus
   `dagger/base.go`'s `golangImage` and
-  `build/Dockerfile.seed-hostpath`'s `FROM golang:` (depName `golang`).
+  `build/Dockerfile.seed-hostpath`'s `FROM golang:` (packageName `golang`).
   CI workflows pick up the Go version from `go.mod` directly via
   `setup-go`'s `go-version-file`.
 - **Version lockstep groups.** When one tool's version is written in two
-  places, the two managers usually mint *different* depNames — so they
-  land in separate PRs and drift unless a packageRule lists both names
-  under one `groupName`. In place today:
+  places, the two managers usually mint *different* package names — so
+  they land in separate PRs and drift unless a packageRule lists both
+  under one `groupName`. Match on **packageName** (`matchPackageNames`);
+  its depName fallback is deprecated and will be removed. In place today:
   `dagger` (`dagger.json` engineVersion + the `dagger.io/dagger` SDK),
   `helm` (`helmImage` in `dagger/base.go`, which lints/tests the chart,
   + `setup-helm` in `release.yaml`, which packages and publishes it —
-  depNames `helm` vs `helm/helm`), and
-  `renovate` (`renovateImage` + the Taskfile's `RENOVATE_IMAGE` —
-  depNames `renovate` vs `renovate/renovate`).
+  packageNames `alpine/helm` vs `helm/helm`), and
+  `renovate` (`renovateImage` + the Taskfile's `RENOVATE_IMAGE` — both
+  resolve to packageName `renovate/renovate`).
   Adding a second write-site for any tool means adding it to its group.
 - `flake.lock` and transitive `go.sum` entries refreshed on every
   Renovate run via `lockFileMaintenance`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -285,6 +285,11 @@ Every other reference is intentionally loose:
   a *bootstrap* image; Renovate keeps it close to `go.mod` for cache
   hits, but if it drifts, Go's `GOTOOLCHAIN=auto` (set in the `goBase`
   helper) downloads the exact toolchain declared in `go.mod` on demand.
+- `build/Dockerfile.seed-hostpath`'s `FROM golang:X.Y.Z-alpine` is the
+  same deal (it compiles the e2e seed binary). It rides in the same
+  Renovate PR as the two above — not because it's listed anywhere, but
+  because the dockerfile manager gives it depName `golang`, which the
+  `golang toolchain` group matches.
 - `flake.nix` uses unpinned `pkgs.go` for the same reason — the dev shell
   runs whatever Go nixpkgs ships, and `GOTOOLCHAIN=auto` handles the rest.
 - The CI workflows use `actions/setup-go@v5` with `go-version-file: go.mod`,
@@ -434,9 +439,22 @@ inside the official Renovate image, sandboxed by Dagger). Highlights:
   `helmImage`, `renovateImage`, `helmDocsImage`), and the
   `golangciLint` / `gotestsumModule` Go install versions in the same
   file.
-- Go-toolchain bumps (gomod + `dagger/base.go` `golangImage`) land in
-  a single PR via `groupName: "golang toolchain"`. CI workflows pick
-  up the Go version from `go.mod` directly via `setup-go`'s
-  `go-version-file`.
+- Go-toolchain bumps land in a single PR via `groupName: "golang
+  toolchain"`: `go.mod` + `dagger/go.mod` (depName `go`), plus
+  `dagger/base.go`'s `golangImage` and
+  `build/Dockerfile.seed-hostpath`'s `FROM golang:` (depName `golang`).
+  CI workflows pick up the Go version from `go.mod` directly via
+  `setup-go`'s `go-version-file`.
+- **Version lockstep groups.** When one tool's version is written in two
+  places, the two managers usually mint *different* depNames — so they
+  land in separate PRs and drift unless a packageRule lists both names
+  under one `groupName`. In place today:
+  `dagger` (`dagger.json` engineVersion + the `dagger.io/dagger` SDK),
+  `helm` (`helmImage` in `dagger/base.go`, which lints/tests the chart,
+  + `setup-helm` in `release.yaml`, which packages and publishes it —
+  depNames `helm` vs `helm/helm`), and
+  `renovate` (`renovateImage` + the Taskfile's `RENOVATE_IMAGE` —
+  depNames `renovate` vs `renovate/renovate`).
+  Adding a second write-site for any tool means adding it to its group.
 - `flake.lock` and transitive `go.sum` entries refreshed on every
   Renovate run via `lockFileMaintenance`.

--- a/renovate.json5
+++ b/renovate.json5
@@ -82,7 +82,8 @@
     // dagger/base.go (tracked by the Dagger module image regex below).
     // This manager only makes the Taskfile copy *visible* to Renovate;
     // what actually keeps the two in step is the `renovate` packageRule
-    // further down, which groups the two differing depNames into one PR.
+    // further down, which groups both write-sites into one PR via their
+    // shared packageName.
     {
       customType: "regex",
       managerFilePatterns: ["/^Taskfile\\.ya?ml$/"],
@@ -248,18 +249,19 @@
     },
 
     // Single PR for all Go-toolchain bumps. Four write-sites land
-    // together, because every one of them resolves to depName `go` or
-    // `golang`:
+    // together, because every one of them resolves to packageName `go`
+    // or `golang` (matchPackageNames matches packageName; its depName
+    // fallback is deprecated and will be removed — never rely on it):
     //
     //   - go.mod          `go` / `toolchain`      (gomod manager  → `go`)
     //   - dagger/go.mod   same                    (gomod manager  → `go`)
-    //   - dagger/base.go  `golangImage`           (regex manager  → `golang`)
+    //   - dagger/base.go  `golangImage`           (regex manager  → image `golang`)
     //   - build/Dockerfile.seed-hostpath `FROM golang:` (dockerfile manager → `golang`)
     //
-    // That last one is easy to miss: it is in the group only because its
-    // depName happens to be `golang`. Renaming the constant or moving the
-    // Dockerfile's base image would silently drop it out of the lockstep,
-    // so keep the depName in mind rather than the file list.
+    // That last two are easy to miss: they are in the group only because
+    // the image is literally named `golang`. Switching either to a
+    // different base image would silently drop it out of the lockstep,
+    // so keep the packageName in mind rather than the file list.
     //
     // CI workflows resolve the Go version via `setup-go` +
     // `go-version-file: go.mod`, so they need no separate bump. flake.nix
@@ -293,12 +295,16 @@
     // with another", and it only surfaces at release time.
     //
     // They don't group on their own because the two managers mint
-    // different depNames: `helm` comes from base.go's `<name>Image`
-    // capture, `helm/helm` from the release.yaml regex (different
-    // datasources too — docker vs github-releases). Listing both names
-    // here is what forces one PR.
+    // different coordinates: base.go's `<name>Image` capture yields
+    // packageName `alpine/helm`, the release.yaml regex yields
+    // `helm/helm` (different datasources too — docker vs
+    // github-releases). Listing both PACKAGE names here is what forces
+    // one PR. Not the depNames (`helm`): matchPackageNames matches
+    // packageName, and its depName fallback is deprecated — relying on
+    // it would split this group again, silently, on a future Renovate
+    // release.
     {
-      matchPackageNames: ["helm", "helm/helm"],
+      matchPackageNames: ["alpine/helm", "helm/helm"],
       groupName: "helm",
       labels: ["dependencies", "helm"],
     },
@@ -306,12 +312,14 @@
     // Same split for Renovate's own image: `renovateImage` in
     // dagger/base.go (used by `dagger call lint-renovate`) vs the
     // Taskfile's RENOVATE_IMAGE (`renovate:plan` / `renovate:patch`).
-    // depNames `renovate` and `renovate/renovate` respectively. Blast
+    // Both resolve to packageName `renovate/renovate` (the Taskfile
+    // regex manager sets no packageNameTemplate, so packageName falls
+    // back to its depName), so a single entry covers the pair. Blast
     // radius is small — debug tooling, not a shipped artifact — but the
     // Taskfile comment promises the two stay aligned, so make that true
     // instead of leaving it to luck.
     {
-      matchPackageNames: ["renovate", "renovate/renovate"],
+      matchPackageNames: ["renovate/renovate"],
       groupName: "renovate",
       labels: ["dependencies"],
     },

--- a/renovate.json5
+++ b/renovate.json5
@@ -79,9 +79,10 @@
     // Renovate image used by the renovate:plan / renovate:patch tasks
     // (Taskfile var RENOVATE_IMAGE — single source of truth, both task
     // bodies template it in). Must stay aligned with `renovateImage` in
-    // dagger/base.go (the Dagger module image regex below tracks the
-    // latter); this manager closes the loop so the Taskfile copy
-    // doesn't drift.
+    // dagger/base.go (tracked by the Dagger module image regex below).
+    // This manager only makes the Taskfile copy *visible* to Renovate;
+    // what actually keeps the two in step is the `renovate` packageRule
+    // further down, which groups the two differing depNames into one PR.
     {
       customType: "regex",
       managerFilePatterns: ["/^Taskfile\\.ya?ml$/"],
@@ -246,12 +247,24 @@
       pinDigests: true,
     },
 
-    // Single PR for all Go-toolchain bumps: go.mod's `go X.Y.Z` and the
-    // dagger/base.go `golangImage` constant land together. CI workflows
-    // resolve the Go version via `setup-go` + `go-version-file: go.mod`,
-    // so they need no separate bump. flake.nix is intentionally unpinned
-    // (GOTOOLCHAIN=auto downloads the toolchain declared in go.mod), so
-    // no manual edit there either.
+    // Single PR for all Go-toolchain bumps. Four write-sites land
+    // together, because every one of them resolves to depName `go` or
+    // `golang`:
+    //
+    //   - go.mod          `go` / `toolchain`      (gomod manager  → `go`)
+    //   - dagger/go.mod   same                    (gomod manager  → `go`)
+    //   - dagger/base.go  `golangImage`           (regex manager  → `golang`)
+    //   - build/Dockerfile.seed-hostpath `FROM golang:` (dockerfile manager → `golang`)
+    //
+    // That last one is easy to miss: it is in the group only because its
+    // depName happens to be `golang`. Renaming the constant or moving the
+    // Dockerfile's base image would silently drop it out of the lockstep,
+    // so keep the depName in mind rather than the file list.
+    //
+    // CI workflows resolve the Go version via `setup-go` +
+    // `go-version-file: go.mod`, so they need no separate bump. flake.nix
+    // is intentionally unpinned (GOTOOLCHAIN=auto downloads the toolchain
+    // declared in go.mod), so no manual edit there either.
     {
       matchPackageNames: ["golang", "go"],
       groupName: "golang toolchain",
@@ -270,6 +283,37 @@
       matchPackageNames: ["busybox", "alpine", "registry"],
       groupName: "container base images",
       labels: ["dependencies", "docker"],
+    },
+
+    // Helm is written in two places that MUST agree: the `alpine/helm`
+    // image in dagger/base.go (lints and tests the chart — lint-helm,
+    // test-helm-{examples,fixtures,render}) and the `azure/setup-helm`
+    // `version:` in release.yaml (packages the chart and pushes it as an
+    // OCI artifact). A skew means "validated with one Helm, published
+    // with another", and it only surfaces at release time.
+    //
+    // They don't group on their own because the two managers mint
+    // different depNames: `helm` comes from base.go's `<name>Image`
+    // capture, `helm/helm` from the release.yaml regex (different
+    // datasources too — docker vs github-releases). Listing both names
+    // here is what forces one PR.
+    {
+      matchPackageNames: ["helm", "helm/helm"],
+      groupName: "helm",
+      labels: ["dependencies", "helm"],
+    },
+
+    // Same split for Renovate's own image: `renovateImage` in
+    // dagger/base.go (used by `dagger call lint-renovate`) vs the
+    // Taskfile's RENOVATE_IMAGE (`renovate:plan` / `renovate:patch`).
+    // depNames `renovate` and `renovate/renovate` respectively. Blast
+    // radius is small — debug tooling, not a shipped artifact — but the
+    // Taskfile comment promises the two stay aligned, so make that true
+    // instead of leaving it to luck.
+    {
+      matchPackageNames: ["renovate", "renovate/renovate"],
+      groupName: "renovate",
+      labels: ["dependencies"],
     },
 
     // Go modules: split patch / minor into two predictable PRs.


### PR DESCRIPTION
## Problem

Two tools have their version written in **two** places each, and Renovate was
bumping those places in **separate PRs** — so they drift.

| Tool | Site A | Site B | depName A | depName B |
|---|---|---|---|---|
| **helm** | `dagger/base.go` `helmImage` (`alpine/helm`) | `release.yaml` `setup-helm` `version:` | `helm` | `helm/helm` |
| **renovate** | `dagger/base.go` `renovateImage` | `Taskfile.yml` `RENOVATE_IMAGE` | `renovate` | `renovate/renovate` |

They look grouped but aren't: the `<name>Image` regex in `dagger/base.go` mints a
depName from the *constant name prefix* (`helm`, `renovate`), which doesn't match the
depName the other manager produces (`helm/helm`, `renovate/renovate`) — and for helm the
datasources differ too (docker vs github-releases). Both pairs happen to be aligned
today (helm 4.2.2, renovate 43.249.2), by luck rather than by construction.

**helm is the one that costs something**: `helmImage` lints and tests the chart
(`lint-helm`, `test-helm-{examples,fixtures,render}`) while `setup-helm` **packages and
publishes** it. A skew means "validated with one Helm, published with another", and it
only shows up at release time.

**renovate is cosmetic** (debug tooling: `renovate:plan` / `renovate:patch` vs
`dagger call lint-renovate`) — but the Taskfile comment claimed the two were kept in
lockstep, which was mechanically false.

## Change

Two packageRules listing both depNames under one `groupName`, so each tool bumps in a
single atomic PR:

```json5
{ matchPackageNames: ["helm", "helm/helm"],           groupName: "helm" },
{ matchPackageNames: ["renovate", "renovate/renovate"], groupName: "renovate" },
```

Plus documentation of a lockstep that already works but was **undocumented and
fragile**: the `golang toolchain` group covers four write-sites — `go.mod`,
`dagger/go.mod` (depName `go`), `dagger/base.go` `golangImage` and
`build/Dockerfile.seed-hostpath` `FROM golang:` (depName `golang`). The Dockerfile is in
the group only because its depName happens to be `golang`; renaming the constant or
changing that base image would silently drop it out. Verified empirically: the recent
1.26.4 → 1.26.5 bump moved all three pinned sites together.

Also corrected the `RENOVATE_IMAGE` manager comment, which claimed the manager alone
prevented drift (it only makes the value *visible*; the group is what synchronises it),
and added a "Version lockstep groups" entry to `CLAUDE.md` so the next person adding a
second write-site knows to extend its group.

## Not included (deliberately)

- No `CheckVersionLockstep` ratchet. Grouping depends on depNames that change when a
  constant is renamed, so a Dagger function *comparing* the coupled values would be
  strictly more robust — but that's a bigger change, and worth it mainly for helm.
  Happy to follow up if wanted.
- No lockstep for things with a single write-site (`k3s`, `kube-prometheus-stack`,
  `golangci-lint`, `gotestsum`, `trivy`, `markdownlint`, `helm-docs`, `helm-schema`,
  `gitleaks`) or for tools coming from unpinned nixpkgs (`cosign`, `kubectl`, `tilt`,
  `k3d`) — adding rules there would be pure ceremony.

## Validation

`renovate-config-validator` passes (`dagger call lint-renovate` → "Config validated
successfully"), `dagger call lint-markdown` → 0 errors. Config-only change; no runtime
or chart output affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded Renovate guidance for Go toolchain versions and bootstrap image management.
  * Documented version-lockstep relationships across Dagger, Helm, and Renovate components.
  * Added guidance for keeping tool versions synchronized across multiple configuration locations.

* **Chores**
  * Improved Renovate configuration comments and grouping rules for related Helm and Renovate updates.
  * Related version updates can now be proposed together for more consistent maintenance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->