### PR TITLE
ci(renovate): stop bumping generated replace directives in dagger/go.mod

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -380,6 +380,23 @@
       labels: ["dependencies", "go"],
     },
 
+    // Never touch the `replace` directives in dagger/go.mod: they are
+    // GENERATED — `dagger develop` pins the otel packages to the exact
+    // versions the Dagger SDK requires and rewrites them on every run.
+    // Any Renovate bump there (PR #682 moved otlploghttp to v0.19.0 as
+    // a security update) is reverted by the next `Dagger module` sync
+    // commit (as on PR #686), looping forever. The pins only really
+    // move when the SDK bumps them upstream, which the `dagger SDK +
+    // engine` group below picks up. `require` entries stay fair game.
+    // Security alerts on these pins can't be remediated here either —
+    // dismiss them on GitHub with that justification.
+    {
+      matchManagers: ["gomod"],
+      matchFileNames: ["dagger/go.mod"],
+      matchDepTypes: ["replace"],
+      enabled: false,
+    },
+
     // Pull dagger.io/dagger out of the broad gomod groups: the SDK in
     // dagger/go.mod and the engineVersion in dagger.json must land
     // together (see the engine regex manager comment for the failure


### PR DESCRIPTION
The `replace` block in `dagger/go.mod` is generated: `dagger develop` pins the otel packages to the exact versions the Dagger SDK requires and rewrites them on every run (reproduced locally with v0.21.8 — it immediately reverts `otlploghttp` v0.19.0 → v0.16.0).

This made #682's security bump a no-op with a delay: Renovate edits the replace → the `Dagger module` sync commit reverts it (#686) → Renovate sees the old version again and re-proposes the security PR, forever.

New packageRule disables gomod updates on `depType: replace` in `dagger/go.mod` only. `require` entries (including the `dagger.io/dagger` SDK group) are unaffected. The pins genuinely move only when Dagger bumps them upstream, which arrives through the `dagger SDK + engine` group.

The Dependabot alert on `otlploghttp` (#17) can't be remediated on our side — worth dismissing on GitHub with "vulnerable code only reachable in sandboxed CI tooling; version pinned by the Dagger SDK generator".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency automation to keep standard dependency updates enabled while excluding selected module replacement directives from automated updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
