### PR TITLE
test(e2e): probe /healthz instead of /metrics on port-forwards

### DIFF
--- a/test/e2e/Tiltfile
+++ b/test/e2e/Tiltfile
@@ -214,9 +214,15 @@ local_resource(
         "19793:9793",
     ]),
     resource_deps=["x509-certificate-exporter"],
+    # Probe /healthz, not /metrics: the prober only drains ~10 KB of
+    # body before closing, and the e2e /metrics payload is much bigger —
+    # every 2s probe would tear the stream down with unread data (RST),
+    # making kubectl port-forward spam "connection reset by peer" /
+    # "broken pipe" unhandled-error logs. /healthz fits in one read and
+    # closes cleanly while still proving the tunnel serves HTTP.
     readiness_probe=probe(
         period_secs=2,
-        http_get=http_get_action(port=19793, path="/metrics"),
+        http_get=http_get_action(port=19793, path="/healthz"),
     ),
 )
 local_resource(
@@ -229,9 +235,10 @@ local_resource(
         "19794:9793",
     ]),
     resource_deps=["x509-certificate-exporter"],
+    # /healthz for the same reason as secrets-port-forward above.
     readiness_probe=probe(
         period_secs=2,
-        http_get=http_get_action(port=19794, path="/metrics"),
+        http_get=http_get_action(port=19794, path="/healthz"),
     ),
 )
 


### PR DESCRIPTION
Tilt's HTTP readiness prober drains only ~10 KB of response body before closing; the e2e /metrics payload is much bigger, so every 2-second probe closed the socket with unread data (RST) and kubectl port-forward logged "connection reset by peer" / "broken pipe" unhandled-error pairs for the whole run. Probing /healthz keeps the end-to-end HTTP validation through the tunnel but fits in a single read and closes cleanly.

Validated with a full `task test:e2e` run: suite green, port-forward error spam gone (1 residual occurrence over the whole run, previously one pair every 2 s).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved end-to-end port-forward readiness checks by using the lightweight health endpoint.
  * Reduced connection-reset logs caused by repeatedly closing larger metrics responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->