### PR TITLE
test(fuzz): cap smoke-run workers to dodge shutdown flake under load

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -230,12 +230,21 @@ tasks:
     # Go fuzz only targets one Fuzz* function at a time, so we list each
     # explicitly. Long-form fuzzing is a manual local activity:
     #   go test -fuzz=<name> -fuzztime=10m ./<pkg>
+    #
+    # -parallel=4 caps the fuzz workers (default GOMAXPROCS): when the
+    # -fuzztime deadline hits, the coordinator cancels the workers'
+    # context and a loaded machine (e.g. `task check` right after the
+    # Dagger unit tests) can miss the grace window, failing the run
+    # with a spurious `context deadline exceeded`. The smoke only
+    # guards against seed-corpus crashes — random-exploration
+    # throughput is not what it's for — so fewer, snappier workers is
+    # the right trade.
     cmds:
-      - go test -run=^$ -fuzz=FuzzParse   -fuzztime=5s ./pkg/cert/pem/
-      - go test -run=^$ -fuzz=FuzzParse   -fuzztime=5s ./pkg/cert/pkcs12/
-      - go test -run=^$ -fuzz=FuzzParse   -fuzztime=5s ./pkg/cert/der/
-      - go test -run=^$ -fuzz=FuzzParse   -fuzztime=5s ./pkg/cert/jks/
-      - go test -run=^$ -fuzz=FuzzCompile -fuzztime=5s ./pkg/fileglob/
+      - go test -run=^$ -fuzz=FuzzParse   -fuzztime=5s -parallel=4 ./pkg/cert/pem/
+      - go test -run=^$ -fuzz=FuzzParse   -fuzztime=5s -parallel=4 ./pkg/cert/pkcs12/
+      - go test -run=^$ -fuzz=FuzzParse   -fuzztime=5s -parallel=4 ./pkg/cert/der/
+      - go test -run=^$ -fuzz=FuzzParse   -fuzztime=5s -parallel=4 ./pkg/cert/jks/
+      - go test -run=^$ -fuzz=FuzzCompile -fuzztime=5s -parallel=4 ./pkg/fileglob/
 
   test:helm-examples:
     desc: "Assert every docs/examples/**/*.values.yaml is accepted by the chart"


### PR DESCRIPTION
The 5s fuzz smoke occasionally fails with `context deadline exceeded` and no crasher: at the -fuzztime deadline the coordinator cancels the workers' context, and with GOMAXPROCS workers (22 here) on a loaded machine — typically `task check` right after the Dagger unit tests — a worker misses the grace window and the run is reported as FAIL. The failing run's own log shows throughput halving in the final seconds; a cold re-run of the identical command passes, and nothing was written to testdata/fuzz (a real corpus regression persists a crasher and names it).

`-parallel=4` keeps shutdown snappy under load. The smoke's job is catching seed-corpus crashes, not maximizing random exploration — corpus entries are already replayed as regular tests by `test:unit`, and long-form fuzzing stays a manual 10-minute activity per the comment.

Validated: full `task test:fuzz` green with the cap.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved fuzz smoke test execution by limiting concurrent fuzz workers.
  * Preserved existing test targets and five-second run durations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->