### PR TITLE
ci(release): drop stale gitleaks-action permission and secrets passthrough

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -86,17 +86,12 @@ jobs:
   # before consuming CI minutes on lint and tests.
   security:
     uses: ./.github/workflows/security.yaml
+    # security.yaml is fully read-only: every scan runs through the
+    # Dagger module (gitleaks is the open-source CLI — no license
+    # secret, no PR comments), so the called workflow needs no write
+    # permission and no secrets passed down.
     permissions:
       contents: read
-      pull-requests: write # gitleaks-action posts on PRs; no-op on tag pushes
-    # `secrets: inherit` propagates GITLEAKS_LICENSE (a repo-level
-    # secret) into the called workflow. Scope is safe: this `security`
-    # job has no `environment:` set, and neither does any job inside
-    # security.yaml — so the `environment: release` secrets used by
-    # the goreleaser/chart jobs below remain out of reach throughout
-    # this chain. `inherit` propagates the calling job's context, not
-    # the entire workflow's.
-    secrets: inherit
   lint:
     needs: security
     uses: ./.github/workflows/lint.yaml


### PR DESCRIPTION
Leftovers from the gitleaks-action era, before secret scanning moved to the open-source gitleaks CLI inside the Dagger module:

- `pull-requests: write` on the release workflow's security gate was only there so gitleaks-action could comment on PRs — nothing in security.yaml writes anymore, so the gate tightens to `contents: read`.
- `secrets: inherit` existed to propagate `GITLEAKS_LICENSE`; that secret no longer exists on the repo and security.yaml consumes no secrets at all, so the passthrough goes away entirely.

No behavior change expected: security.yaml is read-only by construction (its own `permissions: contents: read`), and these comments were the last places still describing the licensed setup.